### PR TITLE
feat: 게시글 정렬 기능 구현

### DIFF
--- a/src/main/java/com/car/sns/domain/UserAccount.java
+++ b/src/main/java/com/car/sns/domain/UserAccount.java
@@ -17,7 +17,7 @@ import java.util.Objects;
                 @Index(columnList = "email", unique = true),
                 @Index(columnList = "createdAt"),
                 @Index(columnList = "createdBy")
-})
+        })
 public class UserAccount extends AuditingFields {
 
     @Id
@@ -26,7 +26,7 @@ public class UserAccount extends AuditingFields {
     private Long userAccountId;
 
     @Column(name = "user_id"
-    , length = 50)
+            , length = 50)
     private String userId;
 
     @Column(name = "user_password"

--- a/src/main/resources/templates/features-posts.html
+++ b/src/main/resources/templates/features-posts.html
@@ -94,16 +94,17 @@
                                     <h4>Posts</h4>
                                 </div>
                                 <div class="card-body">
-                                    <div class="float-left">
+                                    <div id="order-type" class="float-left">
                                         <select class="form-control selectric">
-                                            <option>정렬 조건 필터</option>
-                                            <option>Move to Draft</option>
-                                            <option>Move to Pending</option>
-                                            <option>Delete Pemanently</option>
+                                            <option selected>정렬 조건 필터</option>
+                                            <option class="title"><a href="">Title</a></option>
+                                            <option class="created-by"><a href="">CreatedBy</a></option>
+                                            <option class="created-at"><a href="">CreatedAt</a></option>
+                                            <option class="hashtag"><a href="">Hashtag</a></option>
                                         </select>
                                     </div>
                                     <div class="float-right">
-                                        <form>
+                                        <form id="search-form-box">
                                             <div class="input-group">
                                                 <input type="text" class="form-control" placeholder="Search">
                                                 <div class="input-group-append">

--- a/src/main/resources/templates/features-posts.th.xml
+++ b/src/main/resources/templates/features-posts.th.xml
@@ -5,6 +5,29 @@
 
     <attr sel="tbody" th:remove="all-but-first">
         <attr sel="tr[0]" th:each="article : ${articles}">
+
+            <attr sel="#order-type">
+                <attr sel="select">
+                    <attr sel="option.title/a" th:text="'title'" th:href="@{/articles/index(
+                        page=${article.number},
+                        sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+                        )}">
+                    </attr>
+                        <attr sel="option.created-by/a" th:text="'createdBy'" th:href="@{/articles/index(
+                        page=${article.number},
+                        sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    )}"/>
+                    <attr sel="option.created-at/a" th:text="'createdAt'" th:href="@{/articles/index(
+                        page=${article.number},
+                        sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    )}"/>
+                    <attr sel="option.hashtag/a" th:text="'hashtag'" th:href="@{/articles/index(
+                        page=${article.number},
+                        sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+                    )}"/>
+                </attr>
+            </attr>
+
             <attr sel="td.title" th:text="${article.title}"/>
             <attr sel="td.nickname" th:text="${article.nickname}"/>
             <attr sel="td.created-at" th:text="${article.createdAt}"/>
@@ -29,11 +52,12 @@
             </attr>
         </attr>
 
-        <attr sel="li[2]" th:class="'page-item' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : ' active')">
-              <attr sel="a"
-                    th:text="'Next'"
-                    th:href="@{/articles/index(page=${articles.number + 1})}">
-              </attr>
+        <attr sel="li[2]"
+              th:class="'page-item' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : ' active')">
+            <attr sel="a"
+                  th:text="'Next'"
+                  th:href="@{/articles/index(page=${articles.number + 1})}">
+            </attr>
         </attr>
     </attr>
 </thlogic>

--- a/src/test/java/com/car/sns/controller/ArticleControllerTest.java
+++ b/src/test/java/com/car/sns/controller/ArticleControllerTest.java
@@ -1,16 +1,15 @@
 package com.car.sns.controller;
 
 import com.car.sns.config.SecurityConfig;
-import com.car.sns.domain.Article;
 import com.car.sns.domain.UserAccount;
 import com.car.sns.dto.ArticleDto;
+import com.car.sns.dto.ArticleWithCommentDto;
 import com.car.sns.dto.UserAccountDto;
 import com.car.sns.service.ArticleService;
 import com.car.sns.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -23,6 +22,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static java.nio.file.Paths.get;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,15 +79,15 @@ class ArticleControllerTest {
     @DisplayName("[view] read - 게시글 상세 페이지 - 정상 호출")
     void givenNothing_whenRequestingArticlesView_thenReturnArticleDetail() throws Exception {
         Long articleId = 1L;
-        given(articleService.getArticle(articleId)).willReturn(createdArticle());
+        given(articleService.getArticleWithComments(articleId)).willReturn(createdArticleWithCommentsDto());
 
         mockMvc.perform(MockMvcRequestBuilders.get("/articles/detail/" + articleId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.valueOf("text/html;charset=UTF-8")))
-                .andExpect(view().name("features-posts"))
+                .andExpect(view().name("features-posts-detail"))
                 .andExpect(model().attributeExists("articleDetail"));
 
-        then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleWithComments(articleId);
     }
 
     @Disabled("구현 중")
@@ -118,6 +118,22 @@ class ArticleControllerTest {
                 "content",
                 "hashtag");
     }
+
+    private ArticleWithCommentDto createdArticleWithCommentsDto() {
+        return ArticleWithCommentDto.of(
+                1L,
+                createUserAccountDto(createdUserAccount()),
+                Set.of(),
+                "title",
+                "content",
+                "hashtag",
+                LocalDateTime.now(),
+                "seo",
+                LocalDateTime.now(),
+                "uno");
+    }
+
+
 
     private UserAccount createdUserAccount() {
         return UserAccount.of("userId",


### PR DESCRIPTION
- select 게시글 카테고리 정렬을 통해 필터링이 가능하도록 구현 (제목, 해시태그, 작성일, 작성자)
- 테스트

#36