### PR TITLE
feat: 해시태그 검색 페이지를 위한 기능 구현

### DIFF
--- a/src/main/java/com/car/sns/controller/ArticleController.java
+++ b/src/main/java/com/car/sns/controller/ArticleController.java
@@ -1,7 +1,6 @@
 package com.car.sns.controller;
 
 import com.car.sns.domain.type.SearchType;
-import com.car.sns.dto.ArticleDto;
 import com.car.sns.dto.ArticleWithCommentDto;
 import com.car.sns.dto.response.ArticleResponse;
 import com.car.sns.dto.response.ArticleWithCommentsResponse;
@@ -58,6 +57,24 @@ public class ArticleController {
         map.addAttribute("searchTypes", SearchType.values());
 
         log.info("article response: {}", articleResponses.getContent());
+        return "features-posts";
+    }
+
+    @GetMapping("/hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String hashtagKeyword,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map)
+    {
+        Page<ArticleResponse> articleResponses = articleService.searchArticlesViaHashtag(hashtagKeyword, pageable).map(ArticleResponse::from);
+        List<Integer> paginationBarNumber = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articleResponses.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        map.addAttribute("articles", articleResponses);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", paginationBarNumber);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
         return "features-posts";
     }
 

--- a/src/main/java/com/car/sns/repository/ArticleRepository.java
+++ b/src/main/java/com/car/sns/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.car.sns.repository;
 
 import com.car.sns.domain.Article;
 import com.car.sns.domain.QArticle;
+import com.car.sns.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,7 @@ import java.nio.channels.FileChannel;
 
 @RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long>
+        , ArticleRepositoryCustom
         , QuerydslPredicateExecutor<Article>
         , QuerydslBinderCustomizer<QArticle> {
 

--- a/src/main/java/com/car/sns/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/car/sns/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.car.sns.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtag();
+}

--- a/src/main/java/com/car/sns/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/car/sns/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.car.sns.repository.querydsl;
+
+import com.car.sns.domain.Article;
+import com.car.sns.domain.QArticle;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtag() {
+        QArticle article = QArticle.article;
+
+        return from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull())
+                .fetch();
+    }
+}

--- a/src/main/java/com/car/sns/service/ArticleService.java
+++ b/src/main/java/com/car/sns/service/ArticleService.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -76,5 +78,19 @@ public class ArticleService {
         } catch (EntityNotFoundException e) {
             log.warn("게시글 삭제 실패. 게시글을 찾을 수 없습니다 - articleId: {}", articleId);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagKeyword, Pageable pageable) {
+        if (hashtagKeyword == null || hashtagKeyword.isBlank()) {
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtagKeyword, pageable)
+                .map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtag();
     }
 }

--- a/src/test/java/com/car/sns/controller/ArticleControllerTest.java
+++ b/src/test/java/com/car/sns/controller/ArticleControllerTest.java
@@ -126,14 +126,25 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articles/search"));
     }
 
-    @Disabled("구현 중")
     @Test
     @DisplayName("[view] get - 게시글 해시태그 검색 전용 페이지 - 정상 호출")
     void givenNothing_whenRequestingArticlesView_thenReturnSearchHashtag() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/articles/search-hashtag"))
+        List<String> hashtags = List.of("#pink", "#red", "blue");
+        given(articleService.searchArticlesViaHashtag(eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(articleService.getHashtags()).willReturn(hashtags);
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(1, 2, 3, 4, 5));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/articles/hashtag"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.TEXT_HTML))
-                .andExpect(model().attributeExists("articles/search-hashtag"));
+                .andExpect(content().contentType(MediaType.valueOf("text/html;charset=UTF-8")))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("hashtags"))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attribute("searchType", SearchType.HASHTAG));
+
+        then(articleService).should().searchArticlesViaHashtag(eq(null), any(Pageable.class));
+        then(articleService).should().getHashtags();
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
     private ArticleDto createdArticle() {


### PR DESCRIPTION
- 해시태그를 위한 검색 페이지를 따로 구현
- 테스트
- 해시태그 검색은 view에서 받을 때 hashtag라는 것을 명시하지 않고 서버에서 보내준것을 받는 방법으로 진행

TODO: 해시태그 검색 view 페이지 생성 후 데이터 맵핑할 것

#43