### PR TITLE
feat: 댓글 저장, 삭제 기능

### DIFF
--- a/src/main/java/com/car/sns/controller/ArticleCommentController.java
+++ b/src/main/java/com/car/sns/controller/ArticleCommentController.java
@@ -1,0 +1,45 @@
+package com.car.sns.controller;
+
+import com.car.sns.dto.UserAccountDto;
+import com.car.sns.dto.request.ArticleCommentRequest;
+import com.car.sns.service.ArticleCommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+public class ArticleCommentController {
+
+    private final ArticleCommentService articleCommentService;
+
+    //추가
+    @PostMapping("/new")
+    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
+        //TODO: 사용자 인증 정보 구현
+        log.info("request: {}", articleCommentRequest.toString());
+        UserAccountDto userAccountDto = UserAccountDto.of(null, "Uno", "Uno", "2343", "uno@email.com", "nickname", null);
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(userAccountDto));
+        return "redirect:/articles/detail/" + articleCommentRequest.articleId();
+    }
+
+    //hard delete
+    @DeleteMapping("/{commentId}")
+    public String postDelete(@PathVariable("articleId") Long articleId,
+                             @PathVariable("commentId") Long commentId) {
+        articleCommentService.deleteComment(commentId);
+        return "redirect:/articles/detail/" + articleId;
+    }
+
+    //soft delete
+    @PutMapping("/{articleId}/{commentId}")
+    public String postSoftDelete(@PathVariable("articleId") Long articleId,
+                                 @PathVariable("commentId") Long commentId) {
+        articleCommentService.softDeleteComment(commentId);
+        return "redirect:/articles/detail/" + articleId;
+    }
+}

--- a/src/main/java/com/car/sns/dto/ArticleCommentDto.java
+++ b/src/main/java/com/car/sns/dto/ArticleCommentDto.java
@@ -1,6 +1,8 @@
 package com.car.sns.dto;
 
+import com.car.sns.domain.Article;
 import com.car.sns.domain.ArticleComment;
+import com.car.sns.domain.UserAccount;
 
 import java.time.LocalDateTime;
 
@@ -8,7 +10,7 @@ import java.time.LocalDateTime;
  * DTO for {@link ArticleComment}
  */
 public record ArticleCommentDto(
-        Long ArticleId,
+        Long articleId,
         UserAccountDto userAccountDto,
         LocalDateTime createdAt,
         String createdBy,
@@ -16,20 +18,10 @@ public record ArticleCommentDto(
         String modifiedBy,
         String content
 ) {
-    public ArticleCommentDto(Long ArticleId,
+    public static ArticleCommentDto of(Long articleId,
                              UserAccountDto userAccountDto,
-                             LocalDateTime createdAt,
-                             String createdBy,
-                             LocalDateTime modifiedAt,
-                             String modifiedBy,
                              String content) {
-        this.ArticleId = ArticleId;
-        this.userAccountDto = userAccountDto;
-        this.createdAt = createdAt;
-        this.createdBy = createdBy;
-        this.modifiedAt = modifiedAt;
-        this.modifiedBy = modifiedBy;
-        this.content = content;
+        return new ArticleCommentDto(articleId, userAccountDto, null, null, null, null, content);
     }
 
     public static ArticleCommentDto from(ArticleComment entity) {
@@ -42,5 +34,9 @@ public record ArticleCommentDto(
                 entity.getModifiedBy(),
                 entity.getContent()
         );
+    }
+
+    public ArticleComment toEntity(Article article, UserAccount userAccount) {
+        return ArticleComment.of(userAccount, article, content);
     }
 }

--- a/src/main/java/com/car/sns/dto/request/ArticleCommentRequest.java
+++ b/src/main/java/com/car/sns/dto/request/ArticleCommentRequest.java
@@ -1,0 +1,21 @@
+package com.car.sns.dto.request;
+
+import com.car.sns.dto.ArticleCommentDto;
+import com.car.sns.dto.UserAccountDto;
+
+/**
+ * DTO for {@link com.car.sns.domain.ArticleComment}
+ */
+public record ArticleCommentRequest(
+        Long articleId,
+        String content
+) {
+
+    public static ArticleCommentRequest of(Long articleId, String content) {
+        return new ArticleCommentRequest(articleId, content);
+    }
+
+    public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
+        return ArticleCommentDto.of(articleId, userAccountDto, content);
+    }
+}

--- a/src/main/java/com/car/sns/repository/UserAccountRepository.java
+++ b/src/main/java/com/car/sns/repository/UserAccountRepository.java
@@ -1,0 +1,7 @@
+package com.car.sns.repository;
+
+import com.car.sns.domain.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+}

--- a/src/main/java/com/car/sns/service/ArticleCommentService.java
+++ b/src/main/java/com/car/sns/service/ArticleCommentService.java
@@ -1,7 +1,12 @@
 package com.car.sns.service;
 
+import com.car.sns.domain.Article;
+import com.car.sns.domain.UserAccount;
 import com.car.sns.dto.ArticleCommentDto;
+import com.car.sns.dto.ArticleDto;
 import com.car.sns.repository.ArticleCommentRepository;
+import com.car.sns.repository.ArticleRepository;
+import com.car.sns.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,14 +18,28 @@ import java.util.List;
 @Transactional
 public class ArticleCommentService {
 
+    private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
+    private final UserAccountRepository userAccountRepository;
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> searchArticleComment(long articleId) {
         return List.of();
     }
 
-    public void saveArticleComment(String commentContent) {
+    public void saveArticleComment(ArticleCommentDto articleCommentDto) {
+        Article article = articleRepository.getReferenceById(articleCommentDto.articleId());
+        UserAccount userAccount = userAccountRepository.getReferenceById(articleCommentDto.articleId());
+        articleCommentRepository.save(
+                articleCommentDto.toEntity(article, userAccount)
+        );
+    }
 
+    public void deleteComment(Long commentId) {
+        articleCommentRepository.deleteById(commentId);
+    }
+
+    public void softDeleteComment(Long commentId) {
+        //TODO: soft delete를 위한 컬럼
     }
 }

--- a/src/main/resources/templates/features-posts-detail.html
+++ b/src/main/resources/templates/features-posts-detail.html
@@ -74,7 +74,10 @@
             <div class="card bg-light">
                 <div id="comment-form" class="card-body">
                     <!-- Comment form-->
-                    <form class="mb-4"><textarea class="form-control" rows="3" placeholder="Join the discussion and leave a comment!"></textarea></form>
+                    <form id="comment-form-box" class="mb-4">
+                        <input name="articleId" type="hidden" class="article-id"/>
+                        <textarea class="article-content form-control" rows="3" placeholder="Join the discussion and leave a comment!"></textarea>
+                    </form>
                     <!-- Comment with nested comments-->
                     <!--<div class="d-flex mb-4">
                         &lt;!&ndash; Parent comment&ndash;&gt;

--- a/src/main/resources/templates/features-posts-detail.th.xml
+++ b/src/main/resources/templates/features-posts-detail.th.xml
@@ -8,9 +8,17 @@
         <attr sel=".section-lead" th:text="${articleDetail.hashtag}"></attr>
         <attr sel="#post-content/p" th:text="${articleDetail.content}"></attr>
     </attr>
-    <attr sel="#comment-line" th:each="comment : ${articleDetail.articleCommentDtos}">
-        <attr sel=".comment-content" th:text="${comment.content}">
-            <attr sel=".commmenter-name" th:text="${comment.createdBy}"></attr>
+
+    <attr sel="#comment-form" th:object="${articleDetail}">
+        <!--<attr sel="form" th:action="@{/comments/new}" th:method="post" th:name="commentInfo">
+            <attr sel=".article-id" th:name="articleId" th:value="*{articleCommentDtos.articleId}"></attr>
+            <attr sel=".article-content" th:name="content" ></attr>
+        </attr>-->
+
+        <attr sel="#comment-line" th:each="comment : ${articleDetail.articleCommentDtos}">
+            <attr sel=".comment-content" th:text="${comment.content}">
+                <attr sel=".commmenter-name" th:text="${comment.createdBy}"></attr>
+            </attr>
         </attr>
     </attr>
 </thlogic>

--- a/src/test/java/com/car/sns/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/car/sns/controller/ArticleCommentControllerTest.java
@@ -1,0 +1,56 @@
+package com.car.sns.controller;
+
+import com.car.sns.dto.ArticleCommentDto;
+import com.car.sns.dto.request.ArticleCommentRequest;
+import com.car.sns.service.ArticleCommentService;
+import org.apache.catalina.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("TODO")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleCommentController.class)
+class ArticleCommentControllerTest {
+
+    private final MockMvc mockMvc;
+
+    public ArticleCommentControllerTest(@Autowired MockMvc mockMvc) {
+        this.mockMvc = mockMvc;
+    }
+
+    @MockBean
+    private ArticleCommentService articleCommentService;
+
+    @DisplayName("given_when_then")
+    @Test
+    void givenCommentInfo_whenSavingComment_thenReturnArticleCommentView() throws Exception {
+        //given
+        Long articleId = 1L;
+        willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
+
+        //when
+        mockMvc.perform(post("/comments")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("features-posts-detail"))
+                .andExpect(redirectedUrl("/articles/detail/" + articleId));
+
+        //then
+        then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
+    }
+}

--- a/src/test/java/com/car/sns/controller/ArticleControllerTest.java
+++ b/src/test/java/com/car/sns/controller/ArticleControllerTest.java
@@ -8,7 +8,6 @@ import com.car.sns.dto.ArticleWithCommentDto;
 import com.car.sns.dto.UserAccountDto;
 import com.car.sns.service.ArticleService;
 import com.car.sns.service.PaginationService;
-import io.micrometer.core.instrument.search.Search;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,12 +25,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
-import static java.nio.file.Paths.get;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("view controller - 게시글")

--- a/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
@@ -3,8 +3,10 @@ package com.car.sns.service;
 import com.car.sns.domain.Article;
 import com.car.sns.domain.ArticleComment;
 import com.car.sns.dto.ArticleCommentDto;
+import com.car.sns.dto.UserAccountDto;
 import com.car.sns.repository.ArticleCommentRepository;
 import com.car.sns.repository.ArticleRepository;
+import com.car.sns.repository.UserAccountRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +31,8 @@ class ArticleCommentServiceTest {
     private ArticleRepository articleRepository;
     @Mock
     private ArticleCommentRepository articleCommentRepository;
+    @Mock
+    private UserAccountRepository userAccountRepository;
 
     @DisplayName("게시글 ID로 조회시 관련 댓글을 반환한다")
     @Test
@@ -51,13 +55,24 @@ class ArticleCommentServiceTest {
     @Test
     void givenArticleCommentInfo_whenSavingArticleComments_thenSaveArticleComment() {
         //given
-        given(articleCommentRepository.save(any(ArticleComment.class)))
-                .willReturn(null);
+        ArticleCommentDto commentDto = createdArticleCommentDto("comment content");
+        given(articleRepository.getReferenceById(anyLong())).willReturn(createArticle());
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
 
         //when
-        sut.saveArticleComment("content comment");
+        sut.saveArticleComment(commentDto);
 
         //then
         then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+
+    private ArticleCommentDto createdArticleCommentDto(String content) {
+        UserAccountDto userAccountDto = UserAccountDto.of(null, "uno", "uno", "pw", "email@email.com", "nickname", null);
+        return ArticleCommentDto.of(1L, userAccountDto, content);
+    }
+
+    private Article createArticle() {
+        UserAccountDto userAccountDto = UserAccountDto.of(null, null, "uno", "pw", "email@email.com", "nickname", null);
+        return Article.of(userAccountDto.toEntity(), "title", "content", "hashtag");
     }
 }


### PR DESCRIPTION
- 댓글 저장 후 redirect를 통해 작성한 게시글로 이동하도록 구현
- 댓글 삭제의 경우 hard delete를 구현하였으나 운영 측면에서 soft delete를 할 수 있다.
- 테스트
- 댓글 등록 view 연결하고 테스트할 것

#40

This closes #40 