### PR TITLE
refact: hashcode, equals 비교대상을 getter로 변경

### DIFF
--- a/src/main/java/com/car/sns/domain/board/entity/Article.java
+++ b/src/main/java/com/car/sns/domain/board/entity/Article.java
@@ -69,12 +69,12 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/car/sns/domain/comment/entity/ArticleComment.java
+++ b/src/main/java/com/car/sns/domain/comment/entity/ArticleComment.java
@@ -55,11 +55,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/car/sns/domain/user/entity/UserAccount.java
+++ b/src/main/java/com/car/sns/domain/user/entity/UserAccount.java
@@ -64,11 +64,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return Objects.equals(userAccountId, that.userAccountId);
+        return this.getUserAccountId() != null && this.getUserAccountId().equals(that.getUserAccountId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userAccountId);
+        return Objects.hash(this.getUserAccountId());
     }
 }


### PR DESCRIPTION
- 필드 비교에서 getter 비교로 변경함으로써 지연로딩시 발생할 수 있는 문제 예방

This closes #59