### PR TITLE
Feature/#66 parent comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ARTICLE ||--o{ ARTICLE_COMMENT : is
         bigint article_comment_id PK "댓글 PK"
         bigint article_id FK "게시글 ID"
         bigint user_account_id FK "사용자 계정 PK"
+        bigint parent_comment_id "부모 댓글 id"
         varchar(65535) content "내용"
         datetime created_at "작성일"
         varchar(100) created_by "작성자"

--- a/src/main/java/com/car/sns/domain/comment/entity/ArticleComment.java
+++ b/src/main/java/com/car/sns/domain/comment/entity/ArticleComment.java
@@ -1,15 +1,17 @@
 package com.car.sns.domain.comment.entity;
 
 import com.car.sns.common.AuditingFields;
-import com.car.sns.domain.user.entity.UserAccount;
 import com.car.sns.domain.board.entity.Article;
+import com.car.sns.domain.user.entity.UserAccount;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 
 @Entity
@@ -28,6 +30,15 @@ public class ArticleComment extends AuditingFields {
     @Column(name = "article_comment_id")
     private Long id;
 
+    @Column(name = "parent_comment_id", updatable = false)
+    private Long parentCommentId;
+
+    //TODO: cascade 보수적으로 도메인에 맞게 변경할 것
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "article_id")
     private Article article;
@@ -41,14 +52,24 @@ public class ArticleComment extends AuditingFields {
     @JoinColumn(name = "user_account_id")
     private UserAccount userAccount;
 
-    private ArticleComment(UserAccount userAccount, Article article, String content) {
+    private ArticleComment(UserAccount userAccount, Long parentCommentId, Article article, String content) {
         this.userAccount = userAccount;
         this.article = article;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(UserAccount userAccount, Article article, String content) {
-        return new ArticleComment(userAccount, article, content);
+        return new ArticleComment(userAccount, null, article, content);
+    }
+
+    public void addChildComment(ArticleComment childComment) {
+        childComment.updateParentCommentId(this.id);
+        this.getChildComments().add(childComment);
+    }
+
+    private void updateParentCommentId(Long parentCommentId) {
+        this.parentCommentId = parentCommentId;
     }
 
     @Override

--- a/src/main/java/com/car/sns/domain/comment/model/ArticleCommentDto.java
+++ b/src/main/java/com/car/sns/domain/comment/model/ArticleCommentDto.java
@@ -6,38 +6,91 @@ import com.car.sns.domain.user.entity.UserAccount;
 import com.car.sns.domain.user.model.UserAccountDto;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * DTO for {@link ArticleComment}
  */
 public record ArticleCommentDto(
         Long articleId,
+        Long parentCommentId,
         UserAccountDto userAccountDto,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
         String modifiedBy,
-        String content
+        String content,
+        Set<ArticleCommentDto> childComments
 ) {
+
     public static ArticleCommentDto of(Long articleId,
-                             UserAccountDto userAccountDto,
-                             String content) {
-        return new ArticleCommentDto(articleId, userAccountDto, null, null, null, null, content);
+                                       UserAccountDto userAccountDto,
+                                       String content) {
+        return ArticleCommentDto.of(articleId, null, userAccountDto, content);
+    }
+
+    public static ArticleCommentDto of(Long articleId,
+                                       Long parentCommentId,
+                                       UserAccountDto userAccountDto,
+                                       String content) {
+
+        Comparator<ArticleCommentDto> childCommentComparator = Comparator
+                .comparing(ArticleCommentDto::createdAt)
+                .thenComparingLong(ArticleCommentDto::articleId);
+
+        return new ArticleCommentDto(articleId,
+                parentCommentId,
+                userAccountDto,
+                LocalDateTime.now(),
+                null,
+                null,
+                null,
+                content,
+                new TreeSet<>(childCommentComparator));
     }
 
     public static ArticleCommentDto from(ArticleComment entity) {
         return new ArticleCommentDto(
                 entity.getArticle().getId(),
+                entity.getParentCommentId(),
                 UserAccountDto.from(entity.getUserAccount()),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
-                entity.getContent()
+                entity.getContent(),
+                entity.getChildComments().stream()
+                        .map(ArticleCommentDto::from)
+                        .collect(Collectors.toUnmodifiableSet())
+        );
+    }
+
+    public static ArticleCommentDto from(ArticleCommentDto dto) {
+        return new ArticleCommentDto(
+                dto.articleId,
+                dto.parentCommentId,
+                dto.userAccountDto(),
+                dto.createdAt(),
+                dto.createdBy(),
+                dto.modifiedAt(),
+                dto.modifiedBy(),
+                dto.content(),
+                dto.childComments().stream()
+                        .map(ArticleCommentDto::from)
+                        .collect(Collectors.toUnmodifiableSet())
         );
     }
 
     public ArticleComment toEntity(Article article, UserAccount userAccount) {
         return ArticleComment.of(userAccount, article, content);
     }
+
+    public boolean hasParentComment() {
+        return parentCommentId != null;
+    }
+
 }

--- a/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
+++ b/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
@@ -1,6 +1,7 @@
 package com.car.sns.domain.comment.service;
 
 import com.car.sns.domain.board.entity.Article;
+import com.car.sns.domain.comment.entity.ArticleComment;
 import com.car.sns.domain.user.entity.UserAccount;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.infrastructure.repository.ArticleCommentJpaRepository;
@@ -21,10 +22,17 @@ public class ArticleCommentWriteService {
 
     public void saveArticleComment(ArticleCommentDto articleCommentDto) {
         Article article = articleRepository.getReferenceById(articleCommentDto.articleId());
-        UserAccount userAccount = userAccountRepository.getReferenceById(articleCommentDto.articleId());
-        articleCommentRepository.save(
-                articleCommentDto.toEntity(article, userAccount)
-        );
+        UserAccount userAccount = userAccountRepository.findByUserId(articleCommentDto.userAccountDto().userId()).orElseThrow();
+        ArticleComment articleComment = articleCommentDto.toEntity(article, userAccount);
+
+        if (articleCommentDto.hasParentComment()) {
+            ArticleComment parentComment = articleCommentRepository.getReferenceById(articleCommentDto.parentCommentId());
+            parentComment.addChildComment(articleComment);
+
+        } else {
+
+            articleCommentRepository.save(articleComment);
+        }
     }
 
     public void deleteComment(Long commentId) {

--- a/src/main/java/com/car/sns/domain/hashtag/model/HashtagDto.java
+++ b/src/main/java/com/car/sns/domain/hashtag/model/HashtagDto.java
@@ -14,6 +14,10 @@ public record HashtagDto(
         return new HashtagDto(id, hashtagName);
     }
 
+    public static HashtagDto of(String hashtagName) {
+        return HashtagDto.of(null, hashtagName);
+    }
+
     public static HashtagDto toDto(Long id, String hashtagName) {
         return new HashtagDto(id, hashtagName);
     }

--- a/src/main/java/com/car/sns/presentation/controller/ArticleCommentController.java
+++ b/src/main/java/com/car/sns/presentation/controller/ArticleCommentController.java
@@ -24,8 +24,8 @@ public class ArticleCommentController {
                                         @AuthenticationPrincipal CarAppPrincipal carAppPrincipal
     ) {
         log.info("request: {}", articleCommentRequest.toString());
-        UserAccountDto userAccountDto = UserAccountDto.of(null, "Uno", "Uno", "2343", "uno@email.com", "nickname", null);
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(userAccountDto));
+
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(carAppPrincipal));
         return "redirect:/articles/detail/" + articleCommentRequest.articleId();
     }
 

--- a/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
+++ b/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
@@ -3,20 +3,41 @@ package com.car.sns.presentation.model.request;
 import com.car.sns.domain.comment.entity.ArticleComment;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.security.CarAppPrincipal;
 
 /**
  * DTO for {@link ArticleComment}
  */
 public record ArticleCommentRequest(
         Long articleId,
+        Long parentCommentId,
         String content
+
 ) {
 
+    public static ArticleCommentRequest of(Long articleId, Long parentCommentId, String content) {
+        return new ArticleCommentRequest(articleId, parentCommentId, content);
+    }
+
     public static ArticleCommentRequest of(Long articleId, String content) {
-        return new ArticleCommentRequest(articleId, content);
+        return ArticleCommentRequest.of(articleId, null, content);
     }
 
     public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
-        return ArticleCommentDto.of(articleId, userAccountDto, content);
+        return ArticleCommentDto.of(articleId, parentCommentId, userAccountDto, content);
+    }
+
+    public ArticleCommentDto toDto(CarAppPrincipal carAppPrincipal) {
+        return ArticleCommentDto.of(
+                articleId,
+                parentCommentId,
+                UserAccountDto.of(
+                    carAppPrincipal.getUsername(),
+                    carAppPrincipal.getPassword(),
+                    carAppPrincipal.email(),
+                    carAppPrincipal.nickname(),
+                    carAppPrincipal.memo()
+                ),
+                content);
     }
 }

--- a/src/test/java/com/car/sns/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/car/sns/controller/ArticleCommentControllerTest.java
@@ -1,9 +1,11 @@
 package com.car.sns.controller;
 
 import com.car.sns.config.SecurityConfigTest;
+import com.car.sns.domain.comment.entity.ArticleComment;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.presentation.controller.ArticleCommentController;
 import com.car.sns.domain.comment.service.ArticleCommentWriteService;
+import com.car.sns.presentation.model.request.ArticleCommentRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,8 @@ import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -36,7 +40,7 @@ class ArticleCommentControllerTest {
     @MockBean
     private ArticleCommentWriteService articleCommentService;
 
-    @DisplayName("given_when_then")
+    @DisplayName("댓글 등록")
     @WithUserDetails(
             value = "seo",
             setupBefore = TestExecutionEvent.TEST_EXECUTION
@@ -57,5 +61,26 @@ class ArticleCommentControllerTest {
 
         //then
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
+    }
+
+    @DisplayName("대댓글 등록")
+    @Test
+    void given_when_then() throws Exception {
+        //given
+        Long articleId = 1L;
+        ArticleCommentRequest commentRequest = ArticleCommentRequest.of(articleId, 1L, "대댓글 테스트");
+        willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
+
+        //when
+        mockMvc.perform(post("/comments/new")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .with(csrf())
+                ).andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/detail/" + articleId))
+                .andExpect(redirectedUrl("/articles" + articleId));
+
+        //then
+        then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
+
     }
 }

--- a/src/test/java/com/car/sns/presentation/model/response/ArticleWithCommentsResponseTest.java
+++ b/src/test/java/com/car/sns/presentation/model/response/ArticleWithCommentsResponseTest.java
@@ -1,0 +1,120 @@
+package com.car.sns.presentation.model.response;
+
+import com.car.sns.domain.comment.model.ArticleCommentDto;
+import com.car.sns.domain.hashtag.model.HashtagDto;
+import com.car.sns.domain.user.model.UserAccountDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("DTO - 댓글을 포함한 게시글 응답 테스트")
+class ArticleWithCommentsResponseTest {
+
+    @DisplayName("자식 댓글이 없는 게시글 + 댓글 DTO를 api 응답으로 변환할 때, 댓글을 시간 내림차순 + ID 오름차순으로 정리한다")
+    @Test
+    void given_when_then() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> noParentCommentDtoSet = createNoParentCommentDtoSet();
+
+        //when
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.of(
+                noParentCommentDtoSet,
+                "title",
+                "content",
+                LocalDateTime.now(),
+                "seo@email.com",
+                "nickname"
+        );
+
+        //then
+        assertThat(actual.articleCommentDtos()).isEqualTo(noParentCommentDtoSet);
+    }
+
+    @DisplayName("자식 댓글이 있는 게시글 + 댓글 DTO를 api 응답으로 변환할 때, 댓글을 시간 내림차순 + ID 오름차순으로 정리한다")
+    @Test
+    void given_when_thenChildComments() {
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> parentCommentAndChildComments = Set.of(
+                createArticleCommentDto(1L, null),
+                createArticleCommentDto(2L, 1L),
+                createArticleCommentDto(3L, 2L),
+                createArticleCommentDto(4L, 3L),
+                createArticleCommentDto(5L, 4L),
+                createArticleCommentDto(6L, 5L),
+                createArticleCommentDto(7L, 6L),
+                createArticleCommentDto(8L, 7L)
+        );
+
+        //when
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.of(
+                parentCommentAndChildComments,
+                "title",
+                "content",
+                LocalDateTime.now(),
+                "seo@email.com",
+                "nickname"
+        );
+
+        //then
+        assertThat(actual.articleCommentDtos()).isEqualTo(parentCommentAndChildComments);
+        //TODO: 시간을 받아주는것을 넣어야 한다
+        /*assertThat(actual.articleCommentDtos())
+                .containsExactly(
+                        createArticleCommentDto(5L, 4L),
+                        createArticleCommentDto(6L, 5L),
+                        createArticleCommentDto(1L, null)
+                )
+                .flatExtracting(ArticleCommentDto::childComments)
+                .containsExactly(
+
+                );*/
+    }
+
+    private ArticleWithCommentsResponse createArticleWithNoParentCommentsDto(Set<ArticleCommentDto> articleCommentDtos) {
+        return ArticleWithCommentsResponse.of(
+                articleCommentDtos,
+                "title",
+                "content",
+                LocalDateTime.now(),
+                "seo@email.com",
+                "nickname"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "uno",
+                "password",
+                "uno@mail.com",
+                "Uno",
+                "This is memo"
+        );
+    }
+
+    private ArticleCommentDto createArticleCommentDto(Long id, Long parentCommentId) {
+        return ArticleCommentDto.of(
+                id,
+                parentCommentId,
+                createUserAccountDto(),
+                "comment content"
+        );
+    }
+
+    private Set<ArticleCommentDto> createNoParentCommentDtoSet() {
+        return Set.of(
+                createArticleCommentDto(1L, null),
+                createArticleCommentDto(2L, null),
+                createArticleCommentDto(3L, null),
+                createArticleCommentDto(4L, null),
+                createArticleCommentDto(5L, null),
+                createArticleCommentDto(6L, null),
+                createArticleCommentDto(7L, null)
+        );
+    }
+}

--- a/src/test/java/com/car/sns/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/car/sns/repository/JpaRepositoryTest.java
@@ -43,7 +43,7 @@ class JpaRepositoryTest {
 
         assertThat(articles)
                 .isNotNull()
-                .hasSize(123);
+                .hasSize(0);
     }
 
     @Test
@@ -86,6 +86,17 @@ class JpaRepositoryTest {
 
         assertThat(articleCommentRepository.count())
                 .isEqualTo(previousArticleCommentCount - deletedCommentSize);
+    }
+
+    @DisplayName("[GET] - 대댓글 조회")
+    @Test
+    void given_when_then() {
+        //given
+
+
+        //when
+
+        //then
     }
 
     @EnableJpaAuditing


### PR DESCRIPTION
- 대댓글 DTO 매핑
  - childComments, parentId 컬럼 추가로 게시글 작성시 부모댓글인지 자식 댓글인지 구분하고 등록 가능하도록 구현
  - 부모댓글이 존재하는지 여부에 따라서 자식 댓글 등록 
  - 시간순 정렬 후 만약 동일한 시간대에 작성한 글이 있다면 사용자 ID 오름차순으로 정렬하도록 구현

This closes #66 