### PR TITLE
Feature/#70 kakao oauth login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/car/sns/domain/user/entity/UserAccount.java
+++ b/src/main/java/com/car/sns/domain/user/entity/UserAccount.java
@@ -48,16 +48,24 @@ public class UserAccount extends AuditingFields {
     @Column(name = "memo")
     private String memo;
 
-    private UserAccount(String userId, String userPassword, String email, String nickname, String memo) {
+    @Column(name = "kakao_createdBy")
+    private String oAuthCreatedBy;
+
+    private UserAccount(String userId, String userPassword, String email, String nickname, String memo, String oAuthCreatedBy) {
         this.userId = userId;
         this.userPassword = userPassword;
         this.email = email;
         this.nickname = nickname;
         this.memo = memo;
+        this.oAuthCreatedBy = oAuthCreatedBy;
+    }
+
+    public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo, String oAuthCreatedBy) {
+        return new UserAccount(userId, userPassword, email, nickname, memo, oAuthCreatedBy);
     }
 
     public static UserAccount of(String userId, String userPassword, String email, String nickname, String memo) {
-        return new UserAccount(userId, userPassword, email, nickname, memo);
+        return UserAccount.of(userId, userPassword, email, nickname, memo, null);
     }
 
     @Override

--- a/src/main/java/com/car/sns/domain/user/model/UserAccountDto.java
+++ b/src/main/java/com/car/sns/domain/user/model/UserAccountDto.java
@@ -1,6 +1,8 @@
 package com.car.sns.domain.user.model;
 
 import com.car.sns.domain.user.entity.UserAccount;
+import com.car.sns.security.CarAppPrincipal;
+import com.car.sns.security.KakaoOAuth2Response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
+++ b/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
@@ -1,0 +1,29 @@
+package com.car.sns.domain.user.service;
+
+import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.infrastructure.repository.UserAccountJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserAccountReadService {
+
+    private final UserAccountJpaRepository userAccountJpaRepository;
+
+    /**
+     *  Optional로 반환하는 이유는 해당 service에서 결정하는 것이 아니라
+     *  user만 찾고 이후 단계는 앞단에서 맞는 exception으로 맞춰줄 것
+     */
+    public Optional<UserAccountDto> searchUser(String username) {
+        return userAccountJpaRepository.findByUserId(username)
+                .map(UserAccountDto::from);
+    }
+
+}

--- a/src/main/java/com/car/sns/domain/user/service/UserAccountWriteService.java
+++ b/src/main/java/com/car/sns/domain/user/service/UserAccountWriteService.java
@@ -17,8 +17,8 @@ public class UserAccountWriteService {
 
     private final UserAccountJpaRepository userAccountJpaRepository;
 
-    public UserAccountDto saveUserAccount(KakaoOAuth2Response kakaoOAuth2Response, String password, String memo) {
-        UserAccount userAccount = kakaoOAuth2Response.toUserAccount(password, memo);
+    public UserAccountDto saveUserAccount(KakaoOAuth2Response kakaoOAuth2Response, String dummyPassword) {
+        UserAccount userAccount = kakaoOAuth2Response.toUserAccount(dummyPassword);
         return UserAccountDto.from(userAccountJpaRepository.save(userAccount));
     }
 }

--- a/src/main/java/com/car/sns/domain/user/service/UserAccountWriteService.java
+++ b/src/main/java/com/car/sns/domain/user/service/UserAccountWriteService.java
@@ -1,0 +1,25 @@
+package com.car.sns.domain.user.service;
+
+import com.car.sns.domain.user.entity.UserAccount;
+import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.infrastructure.repository.UserAccountJpaRepository;
+import com.car.sns.security.KakaoOAuth2Response;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAccountWriteService {
+
+    private final UserAccountJpaRepository userAccountJpaRepository;
+
+    public UserAccountDto saveUserAccount(KakaoOAuth2Response kakaoOAuth2Response, String password, String memo) {
+        UserAccount userAccount = kakaoOAuth2Response.toUserAccount(password, memo);
+        return UserAccountDto.from(userAccountJpaRepository.save(userAccount));
+    }
+}
+

--- a/src/main/java/com/car/sns/security/CarAppPrincipal.java
+++ b/src/main/java/com/car/sns/security/CarAppPrincipal.java
@@ -4,8 +4,10 @@ import com.car.sns.domain.user.model.UserAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,11 +18,12 @@ public record CarAppPrincipal(
         String password,
         String email,
         String nickname,
-        String memo
+        String memo,
+        Map<String, Object> oAuth2Attribute
 
-) implements UserDetails {
+) implements UserDetails, OAuth2User {
 
-    public static CarAppPrincipal of(String username, String password, String email, String nickname, String memo) {
+    public static CarAppPrincipal of(String username, String password, String email, String nickname, String memo, Map<String, Object> oAuth2Attribute) {
         Set<RoleType> roleTypes = Set.of(RoleType.USER);
 
         return new CarAppPrincipal(
@@ -32,7 +35,12 @@ public record CarAppPrincipal(
                 password,
                 email,
                 nickname,
-                memo);
+                memo,
+                oAuth2Attribute);
+    }
+
+    public static CarAppPrincipal of(String username, String password, String email, String nickname, String memo) {
+        return CarAppPrincipal.of(username, password, email, nickname, memo, Map.of());
     }
 
     public static CarAppPrincipal from(UserAccountDto userAccountDto) {
@@ -48,12 +56,23 @@ public record CarAppPrincipal(
         return UserAccountDto.of(username, password, email, nickname, memo);
     }
 
+    /**
+     * OAuth2 method
+     */
+
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        //권한
-        return null;
+    public Map<String, Object> getAttributes() {
+        return oAuth2Attribute;
     }
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    /**
+     * Spring security method
+     */
     @Override
     public String getPassword() {
         return password;
@@ -82,5 +101,10 @@ public record CarAppPrincipal(
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    @Override
+    public String getName() {
+        return username;
     }
 }

--- a/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
+++ b/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
@@ -1,5 +1,7 @@
 package com.car.sns.security;
 
+import com.car.sns.domain.user.entity.UserAccount;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -58,6 +60,17 @@ public record KakaoOAuth2Response(
                 (Map<String, Object>) attributes.get("properties"),
                 KakaoAccount.from((Map<String, Object>) attributes.get("kakao_account"))
         );
+    }
+
+    public UserAccount toUserAccount(String password, String memo) {
+        return UserAccount.of(
+                nickname(),
+                password,
+                this.email(),
+                this.nickname(),
+                memo,
+                nickname()
+                );
     }
 
     public String email() {

--- a/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
+++ b/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
@@ -1,0 +1,71 @@
+package com.car.sns.security;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+/**
+ * 카카오 OAuth login 문서
+ * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
+ */
+@SuppressWarnings("unchecked") // TODO: Map -> Object 변환 로직이 있어 제네릭 타입 캐스팅 문제를 무시한다. 더 좋은 방법이 있다면 고려할 수 있음.
+public record KakaoOAuth2Response(
+        Long id,
+        LocalDateTime connectedAt,
+        Map<String, Object> properties,
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            Boolean profileNicknameNeedsAgreement,
+            Profile profile,
+            Boolean hasEmail,
+            Boolean emailNeedsAgreement,
+            Boolean isEmailValid,
+            Boolean isEmailVerified,
+            String email
+    ) {
+        public record Profile(String nickname) {
+            public static Profile from(Map<String, Object> attributes) {
+                return new Profile(String.valueOf(attributes.get("nickname")));
+            }
+        }
+
+        public static KakaoAccount from(Map<String, Object> attributes) {
+            return new KakaoAccount(
+                    Boolean.valueOf(String.valueOf(attributes.get("profile_nickname_needs_agreement"))),
+                    Profile.from((Map<String, Object>) attributes.get("profile")),
+                    Boolean.valueOf(String.valueOf(attributes.get("has_email"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("email_needs_agreement"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_valid"))),
+                    Boolean.valueOf(String.valueOf(attributes.get("is_email_verified"))),
+                    String.valueOf(attributes.get("email"))
+            );
+        }
+
+        public String nickname() {
+            return this.profile().nickname();
+        }
+    }
+
+    public static KakaoOAuth2Response from(Map<String, Object> attributes) {
+        return new KakaoOAuth2Response(
+                Long.valueOf(String.valueOf(attributes.get("id"))),
+                LocalDateTime.parse(
+                        String.valueOf(attributes.get("connected_at")),
+                        DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault())
+                ),
+                (Map<String, Object>) attributes.get("properties"),
+                KakaoAccount.from((Map<String, Object>) attributes.get("kakao_account"))
+        );
+    }
+
+    public String email() {
+        return this.kakaoAccount().email();
+    }
+
+    public String nickname() {
+        return this.kakaoAccount().nickname();
+    }
+
+}

--- a/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
+++ b/src/main/java/com/car/sns/security/KakaoOAuth2Response.java
@@ -62,13 +62,13 @@ public record KakaoOAuth2Response(
         );
     }
 
-    public UserAccount toUserAccount(String password, String memo) {
+    public UserAccount toUserAccount(String dummyPassword) {
         return UserAccount.of(
                 nickname(),
-                password,
+                dummyPassword,
                 this.email(),
                 this.nickname(),
-                memo,
+                null,
                 nickname()
                 );
     }

--- a/src/test/java/com/car/sns/domain/user/service/UserAccountReadServiceTest.java
+++ b/src/test/java/com/car/sns/domain/user/service/UserAccountReadServiceTest.java
@@ -1,0 +1,65 @@
+package com.car.sns.domain.user.service;
+
+import com.car.sns.domain.user.entity.UserAccount;
+import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.infrastructure.repository.UserAccountJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("TODO")
+@ExtendWith(MockitoExtension.class)
+class UserAccountReadServiceTest {
+
+    @InjectMocks
+    private UserAccountReadService sut;
+
+    @Mock
+    private UserAccountJpaRepository userAccountJpaRepository;
+
+    @DisplayName("회원 아이디가 존재하면 회원 데이터를 Optional로 반환")
+    @Test
+    void givenUsername_whenSearchingUserAccount_thenReturnOptionalUserAccount() {
+        //given
+        String username = "seo";
+        given(userAccountJpaRepository.findByUserId(username))
+                .willReturn(Optional.of(createUserAccount(username)));
+
+        //when
+        Optional<UserAccountDto> result = sut.searchUser(username);
+
+        //then
+        assertThat(result).isPresent();
+        then(userAccountJpaRepository).should().findByUserId(username);
+
+    }
+
+    private UserAccount createUserAccount(String username) {
+        return createUserAccount(username, null);
+    }
+
+    private UserAccount createSigningUpUserAccount(String username) {
+        return createUserAccount(username, username);
+    }
+
+    private UserAccount createUserAccount(String username, String createdBy) {
+        return UserAccount.of(
+                username,
+                "password",
+                "e@mail.com",
+                "nickname",
+                "memo",
+                createdBy
+        );
+    }
+}

--- a/src/test/java/com/car/sns/domain/user/service/UserAccountWriteServiceTest.java
+++ b/src/test/java/com/car/sns/domain/user/service/UserAccountWriteServiceTest.java
@@ -1,0 +1,33 @@
+package com.car.sns.domain.user.service;
+
+import com.car.sns.infrastructure.repository.UserAccountJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("사용자 등록 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class UserAccountWriteServiceTest {
+
+    @InjectMocks
+    private UserAccountWriteService sut;
+
+    @Mock
+    private UserAccountJpaRepository userAccountJpaRepository;
+
+    @DisplayName("given_when_then")
+    @Test
+    void givenKakaoOAuth2Response_whenSavingUserAccount_thenReturnUserAccountDto() {
+        //given
+
+        //when
+
+        //then
+    }
+}

--- a/src/test/java/com/car/sns/security/KakaoOAuth2ResponseTest.java
+++ b/src/test/java/com/car/sns/security/KakaoOAuth2ResponseTest.java
@@ -1,0 +1,58 @@
+package com.car.sns.security;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DTO - Kakao OAuth 2.0 인증 응답 데이터 테스트")
+class KakaoOAuth2ResponseTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @DisplayName("인증 결과를 Map(deserialized json)으로 받으면, 카카오 인증 응답 객체로 변환한다.")
+    @Test
+    void givenMapFromJson_whenInstantiating_thenReturnsKakaoResponseObject() throws Exception {
+        // Given
+        String serializedResponse = """
+                {
+                    "id": 1234567890,
+                    "connected_at": "2022-01-02T00:12:34Z",
+                    "properties": {
+                        "nickname": "홍길동"
+                    },
+                    "kakao_account": {
+                        "profile_nickname_needs_agreement": false,
+                        "profile": {
+                            "nickname": "홍길동"
+                        },
+                        "has_email": true,
+                        "email_needs_agreement": false,
+                        "is_email_valid": true,
+                        "is_email_verified": true,
+                        "email": "test@gmail.com"
+                    }
+                }
+                """;
+        Map<String, Object> attributes = mapper.readValue(serializedResponse, new TypeReference<>() {});
+
+        // When
+        KakaoOAuth2Response result = KakaoOAuth2Response.from(attributes);
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("id", 1234567890L)
+                .hasFieldOrPropertyWithValue("connectedAt", ZonedDateTime.of(2022, 1, 2, 0, 12, 34, 0, ZoneOffset.UTC)
+                        .withZoneSameInstant(ZoneId.systemDefault())
+                        .toLocalDateTime()
+                )
+                .hasFieldOrPropertyWithValue("kakaoAccount.profile.nickname", "홍길동")
+                .hasFieldOrPropertyWithValue("kakaoAccount.email", "test@gmail.com");
+    }
+}


### PR DESCRIPTION

OAuth2 Client를 사용하여 kakao login 적용 

- [x]  https://developers.kakao.com/ 에서 카카오 API 사용 준비
- [x]  회원 도메인이 인증 없는 상태에서 회원 정보를 저장할 수 있게 수정
- [x]  카카오 인증 응답 정보 확인 / 정의
- [x]  OAuth 2.0 보안 설정 (람다식 접근)
- [x]  OAuth2UserService 구현
- [x]  기본 인증 서비스 로직 구현

This closes #70