### PR TITLE
refact: active profiles 환경 변수 데이터 관리를 위해 envFile 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ application-local.yml
 
 # JPA Buddy
 .jpb/
+
+#env
+/src/main/resources/env


### PR DESCRIPTION
- env 파일은 민감 정보로 이루어져 있기 때문에 .gitignore에서 제외한다

This closes #78