### PR TITLE
refact: spring security + JWT 로그인 수정

### DIFF
--- a/src/main/java/com/car/sns/application/usecase/user/UserReadUseCase.java
+++ b/src/main/java/com/car/sns/application/usecase/user/UserReadUseCase.java
@@ -1,0 +1,7 @@
+package com.car.sns.application.usecase.user;
+
+import com.car.sns.domain.user.model.LoginDto;
+
+public interface UserReadUseCase {
+    String login(LoginDto loginDto);
+}

--- a/src/main/java/com/car/sns/config/JpaConfig.java
+++ b/src/main/java/com/car/sns/config/JpaConfig.java
@@ -1,26 +1,9 @@
 package com.car.sns.config;
 
-import com.car.sns.security.CarAppPrincipal;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-
-import java.util.Optional;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
-    @Bean
-    public AuditorAware<String> auditorAware() {
-        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
-                .map(SecurityContext::getAuthentication)
-                .filter(Authentication::isAuthenticated)
-                .map(Authentication::getPrincipal)
-                .map(CarAppPrincipal.class::cast)
-                .map(CarAppPrincipal::username);
-    }
 }

--- a/src/main/java/com/car/sns/domain/board/repository/ArticleRepository.java
+++ b/src/main/java/com/car/sns/domain/board/repository/ArticleRepository.java
@@ -1,7 +1,7 @@
 package com.car.sns.domain.board.repository;
 
 import com.car.sns.domain.board.model.entity.Article;
-import com.car.sns.domain.board.entity.QArticle;
+import com.car.sns.domain.board.model.entity.QArticle;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/car/sns/domain/board/repository/querydsl/HashtagRepositoryCustomImpl.java
+++ b/src/main/java/com/car/sns/domain/board/repository/querydsl/HashtagRepositoryCustomImpl.java
@@ -1,7 +1,7 @@
 package com.car.sns.domain.board.repository.querydsl;
 
 import com.car.sns.domain.hashtag.model.entity.Hashtag;
-import com.car.sns.domain.hashtag.entity.QHashtag;
+import com.car.sns.domain.hashtag.model.entity.QHashtag;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.List;

--- a/src/main/java/com/car/sns/domain/user/model/LoginDto.java
+++ b/src/main/java/com/car/sns/domain/user/model/LoginDto.java
@@ -1,0 +1,12 @@
+package com.car.sns.domain.user.model;
+
+import com.car.sns.presentation.model.request.UserLoginRequest;
+
+public record LoginDto(
+        String userId,
+        String password
+) {
+    public static LoginDto from(UserLoginRequest loginRequest) {
+        return new LoginDto(loginRequest.userId(), loginRequest.password());
+    }
+}

--- a/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
+++ b/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
@@ -1,20 +1,32 @@
 package com.car.sns.domain.user.service;
 
+import com.car.sns.application.usecase.user.UserReadUseCase;
+import com.car.sns.domain.user.model.LoginDto;
 import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.exception.CarHrSnsAppException;
 import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
+import com.car.sns.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import static com.car.sns.exception.model.AppErrorCode.INVALID_USER_ID_PASSWORD;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class UserAccountReadService {
+public class UserAccountReadService implements UserReadUseCase {
 
+    @Value("${jwt.token.secret}")
+    private String secretKey;
+    private long expireTimeMs = 1000 * 60 * 60; //TODO:test를 위한것으로 Redis implement
+    private final PasswordEncoder passwordEncoder;
     private final UserAccountJpaRepository userAccountJpaRepository;
 
     /**
@@ -26,4 +38,18 @@ public class UserAccountReadService {
                 .map(UserAccountDto::from);
     }
 
+    @Override
+    public String login(LoginDto loginDto) {
+        UserAccountDto userAccountDto = userAccountJpaRepository.findByUserId(loginDto.userId())
+                .filter(user -> passwordEncoder.matches(loginDto.password(), user.getUserPassword()))
+                .map(UserAccountDto::from)
+                .orElseThrow(() -> {
+                    throw new CarHrSnsAppException(INVALID_USER_ID_PASSWORD, INVALID_USER_ID_PASSWORD.getMessage());
+                });
+        log.info("login userAccountDto: {}", userAccountDto);
+
+        String token = JwtUtil.createToken(userAccountDto.userId(), secretKey, expireTimeMs);
+        log.info("token: {}", token);
+        return token;
+    }
 }

--- a/src/main/java/com/car/sns/infrastructure/jpaRepository/ArticleCommentJpaRepository.java
+++ b/src/main/java/com/car/sns/infrastructure/jpaRepository/ArticleCommentJpaRepository.java
@@ -1,7 +1,7 @@
 package com.car.sns.infrastructure.jpaRepository;
 
 import com.car.sns.domain.comment.model.entity.ArticleComment;
-import com.car.sns.domain.comment.entity.QArticleComment;
+import com.car.sns.domain.comment.model.entity.QArticleComment;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/car/sns/presentation/controller/ArticleController.java
+++ b/src/main/java/com/car/sns/presentation/controller/ArticleController.java
@@ -40,7 +40,7 @@ public class ArticleController {
      * searchType, searchKeyword 존재 X : 게시글 전체 조회
      * searchType, searchKeyword 존재 O : 타입/키워드를 필터링으로 해당 게시글 조회
      */
-    @GetMapping("")
+    @GetMapping("/index")
     public ResponseEntity<ArticlePageResponse> getAllOrSearchArticles(
             @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchKeyword,

--- a/src/main/java/com/car/sns/presentation/controller/UserController.java
+++ b/src/main/java/com/car/sns/presentation/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.car.sns.presentation.controller;
+
+import com.car.sns.application.usecase.user.UserManagementUseCase;
+import com.car.sns.application.usecase.user.UserReadUseCase;
+import com.car.sns.domain.user.model.LoginDto;
+import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.presentation.model.request.RegisterAccountRequest;
+import com.car.sns.presentation.model.request.UserLoginRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserManagementUseCase userManagementUseCase;
+    private final UserReadUseCase userReadUseCase;
+
+    @PostMapping("/register")
+    public ResponseEntity<UserAccountDto> userRegister(@RequestBody RegisterAccountRequest registerAccountRequest) {
+        UserAccountDto userAccountDto = userManagementUseCase.userRegisterAccount(registerAccountRequest);
+        log.info("userAccountDto: {}", userAccountDto);
+        return ResponseEntity
+                .ok()
+                .body(userAccountDto);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody UserLoginRequest userLoginRequest) {
+        log.info("userLoginRequest: {}", userLoginRequest);
+        return ResponseEntity
+                .ok()
+                .body(userReadUseCase.login(LoginDto.from(userLoginRequest)));
+    }
+}

--- a/src/main/java/com/car/sns/presentation/model/request/UserLoginRequest.java
+++ b/src/main/java/com/car/sns/presentation/model/request/UserLoginRequest.java
@@ -1,0 +1,11 @@
+package com.car.sns.presentation.model.request;
+
+public record UserLoginRequest(
+        String userId,
+        String password
+) {
+    public UserLoginRequest(String userId, String password) {
+        this.userId = userId;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/car/sns/security/JwtTokenFilter.java
+++ b/src/main/java/com/car/sns/security/JwtTokenFilter.java
@@ -1,0 +1,27 @@
+package com.car.sns.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        //권한을 주거나 주지 않는다 ( 입장 ex) 티켓 확인)
+        //개찰구 역할
+        //현재는 모두 닫혀 있습니다
+        log.info("doFilter in CustomOncePerRequestFilter");
+        //문 열어주기
+        /*UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken( );
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);*/
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/car/sns/security/JwtUtil.java
+++ b/src/main/java/com/car/sns/security/JwtUtil.java
@@ -1,0 +1,22 @@
+package com.car.sns.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    public static String createToken(String userId, String key, long expireTile) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis())) //지금 시간부터
+                .setExpiration(new Date(System.currentTimeMillis() + expireTile)) //언제까지
+                .signWith(SignatureAlgorithm.HS512, key)
+                .compact();
+    }
+}


### PR DESCRIPTION
- 기존의 spring security 기본 로그인 사용하였는데 추후 커스텀될 가능성이 있기 때문에 직접 구현
- 로그인 model 생성하여 반환할 수 있도록 구현

This closes #86