### PR TITLE
refact: Auditing createdBy 적용 안되는 현상 해결

### DIFF
--- a/src/main/java/com/car/sns/common/AuditorJpaAwareImpl.java
+++ b/src/main/java/com/car/sns/common/AuditorJpaAwareImpl.java
@@ -1,0 +1,26 @@
+package com.car.sns.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+@Slf4j
+@Configuration
+@EnableJpaAuditing
+public class AuditorJpaAwareImpl implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            log.debug("Not found AuthenticationToken");
+            return null;
+        }
+
+        return Optional.of(authentication.getName());
+    }
+}

--- a/src/main/java/com/car/sns/config/JpaConfig.java
+++ b/src/main/java/com/car/sns/config/JpaConfig.java
@@ -1,9 +1,0 @@
-package com.car.sns.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaConfig {
-}


### PR DESCRIPTION
- 단순히 Auditing만 설정하고 따로 지정해주지 않아서 문제 발생한 것으로 JPA AuditorAware<String> 구현 받아서 해결

#90