### PR TITLE
bug: content에서 해시태그 파싱해서 저장하는 로직 버그

### DIFF
--- a/src/main/java/com/car/sns/domain/board/service/ArticleWriteService.java
+++ b/src/main/java/com/car/sns/domain/board/service/ArticleWriteService.java
@@ -58,7 +58,8 @@ public class ArticleWriteService implements ArticleManagementUseCase {
         Article article = Article.of(accessUser, createArticleInfoDto.title(), createArticleInfoDto.content());
         Article response = articleRepository.save(article);
 
-        //hashtagWriteService.renewHashtagsFromContent(article.getContent());
-        return Result.success(ArticleDto.from(article));
+        //TODO: 게시글 생성시 해시태그를 생성하여 저장하는 방식인데 사용자가 모를 경우 null 입력 받음
+        hashtagWriteService.renewHashtagsFromContent(article.getContent());
+        return Result.success(ArticleDto.from(response));
     }
 }

--- a/src/main/java/com/car/sns/domain/hashtag/service/HashtagWriteService.java
+++ b/src/main/java/com/car/sns/domain/hashtag/service/HashtagWriteService.java
@@ -25,16 +25,19 @@ public class HashtagWriteService {
     public void renewHashtagsFromContent(String content) {
         //게시글 작성시 별도 입력을 하지 않고 본문에서 해시태그 파싱
         Set<String> hashtagNamesInContent = hashtagReadService.parseHashtagNames(content);
+
+        if (hashtagNamesInContent.isEmpty()) {
+            return;
+        }
+
         Set<String> existingHashtagNames = hashtagReadService.findHashtagByNames(hashtagNamesInContent)
                 .stream().collect(Collectors.toUnmodifiableSet());
 
-        if (!hashtagNamesInContent.isEmpty()) {
-            hashtagNamesInContent.forEach(newHashtagName -> {
-                if (!existingHashtagNames.contains(newHashtagName)) {
-                    hashtagJpaRepository.save(Hashtag.of(newHashtagName));
-                }
-            });
-        }
+        hashtagNamesInContent.forEach(newHashtagName -> {
+            if (!existingHashtagNames.contains(newHashtagName)) {
+                hashtagJpaRepository.save(Hashtag.of(newHashtagName));
+            }
+        });
     }
 
 }

--- a/src/main/java/com/car/sns/domain/hashtag/service/read/HashtagReadService.java
+++ b/src/main/java/com/car/sns/domain/hashtag/service/read/HashtagReadService.java
@@ -68,6 +68,8 @@ public class HashtagReadService implements HashtagUseCase {
             result.add(matcher.group().replace("#", ""));
         }
 
+        log.info("parse content: {}", result.stream().toList());
+
         return Set.copyOf(result);
     }
 

--- a/src/main/java/com/car/sns/infrastructure/jpaRepository/HashtagJpaRepository.java
+++ b/src/main/java/com/car/sns/infrastructure/jpaRepository/HashtagJpaRepository.java
@@ -12,5 +12,6 @@ public interface HashtagJpaRepository extends JpaRepository<Hashtag, Long> , Has
     @Query("select a.id from Hashtag a where a.hashtagName LIKE CONCAT('%',:hashtag,'%')")
     Set<Long> findByHashtag(@Param("hashtag") String hashtag);
 
-    Set<String> findByHashtagNameIn(Set<String> hashtagNames);
+    @Query("SELECT h FROM Hashtag h WHERE h.hashtagName IN :hashtagName")
+    Set<String> findByHashtagNameIn(@Param("hashtagName") Set<String> hashtagName);
 }


### PR DESCRIPTION
- spring Data JPA JPQL 게시글 content에서 해시태그 Parsing 해서 해시태그 저장하는 부분에서 해시태그 저장안되는 현상 발생
- @Query를 통해 명시

This closes #94