### PR TITLE
bug: spring security token만료 예외처리 필요

### DIFF
--- a/src/main/java/com/car/sns/config/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/car/sns/config/AuthenticationEntryPointImpl.java
@@ -1,0 +1,21 @@
+package com.car.sns.config;
+
+import com.car.sns.presentation.model.response.Result;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+import static com.car.sns.exception.model.AppErrorCode.INVALID_TOKEN;
+
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setStatus(INVALID_TOKEN.getStatus().value());
+        response.getWriter().write(Result.error(INVALID_TOKEN.getMessage()).getResult());
+    }
+}

--- a/src/main/java/com/car/sns/config/SecurityConfig.java
+++ b/src/main/java/com/car/sns/config/SecurityConfig.java
@@ -81,6 +81,8 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)
                         )
+                ).exceptionHandling( ex ->
+                    ex.authenticationEntryPoint(new AuthenticationEntryPointImpl())
                 ).build();
     }
 

--- a/src/main/java/com/car/sns/exception/model/AppErrorCode.java
+++ b/src/main/java/com/car/sns/exception/model/AppErrorCode.java
@@ -15,7 +15,8 @@ public enum AppErrorCode {
     INVALID_USER_ID_PASSWORD            ("UA0003", HttpStatus.FORBIDDEN, "아이디 또는 비밀번호가 일치하지 않습니다. 회원정보를 확인해주세요"),
 
     //토큰 만료
-    AUTHENTICATION_TOKEN_EXIST          ("A0001", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.");
+    AUTHENTICATION_TOKEN_EXIST          ("A0001", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
+    INVALID_TOKEN                       ("A0002", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다");
 
     private String errorCode;
     private HttpStatus status;


### PR DESCRIPTION
- filter 단에서 TOKEN이 만료되거나 유효하지 않은 토큰인 경우 서버 에러 발생
- Exception 발생하도록 config 설정 추가

This closes #96