### PR TITLE
bug: 게시글 수정시 수정요청자, 작성자 일치여부 확인

### DIFF
--- a/src/main/java/com/car/sns/domain/board/model/entity/Article.java
+++ b/src/main/java/com/car/sns/domain/board/model/entity/Article.java
@@ -42,7 +42,8 @@ public class Article extends AuditingFields {
     private Set<ArticleComment> articleComment = new HashSet<>();*/
 
     @ManyToOne(optional = false,
-            cascade = CascadeType.ALL)
+            cascade = CascadeType.ALL,
+            fetch = FetchType.LAZY)
     @JoinColumn(name = "user_account_id")
     private UserAccount userAccount;
 

--- a/src/main/java/com/car/sns/domain/board/repository/ArticleJpaRepository.java
+++ b/src/main/java/com/car/sns/domain/board/repository/ArticleJpaRepository.java
@@ -15,7 +15,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface ArticleRepository extends JpaRepository<Article, Long>
+public interface ArticleJpaRepository extends JpaRepository<Article, Long>
         , QuerydslPredicateExecutor<Article>
         , QuerydslBinderCustomizer<QArticle> {
 

--- a/src/main/java/com/car/sns/domain/board/service/read/ArticleReadService.java
+++ b/src/main/java/com/car/sns/domain/board/service/read/ArticleReadService.java
@@ -3,7 +3,7 @@ package com.car.sns.domain.board.service.read;
 import com.car.sns.application.usecase.board.ArticleReaderUseCase;
 import com.car.sns.domain.board.model.ArticleDto;
 import com.car.sns.domain.board.model.type.SearchType;
-import com.car.sns.domain.board.repository.ArticleRepository;
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import com.car.sns.domain.hashtag.service.read.HashtagReadService;
 import com.car.sns.presentation.model.response.ArticleDetailWithCommentResponse;
 import jakarta.persistence.EntityNotFoundException;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ArticleReadService implements ArticleReaderUseCase {
 
-    private final ArticleRepository articleRepository;
+    private final ArticleJpaRepository articleRepository;
     private final HashtagReadService hashtagReadService;
 
     @Override

--- a/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
+++ b/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
@@ -6,7 +6,7 @@ import com.car.sns.domain.comment.model.entity.ArticleComment;
 import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
-import com.car.sns.domain.board.repository.ArticleRepository;
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ArticleCommentWriteService implements ArticleCommentManagementUseCase {
 
-    private final ArticleRepository articleRepository;
+    private final ArticleJpaRepository articleRepository;
     private final ArticleCommentJpaRepository articleCommentRepository;
     private final UserAccountJpaRepository userAccountRepository;
 

--- a/src/main/java/com/car/sns/exception/model/AppErrorCode.java
+++ b/src/main/java/com/car/sns/exception/model/AppErrorCode.java
@@ -16,7 +16,11 @@ public enum AppErrorCode {
 
     //토큰 만료
     AUTHENTICATION_TOKEN_EXIST          ("A0001", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다"),
-    INVALID_TOKEN                       ("A0002", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다");
+    INVALID_TOKEN                       ("A0002", HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다"),
+
+    //서비스
+    USER_NOT_MATCH                      ("SV0001", HttpStatus.FORBIDDEN, "작성자와 요청자가 일치하지 않습니다"),
+    ENTITY_NOT_FOUND                    ("SV1001", HttpStatus.NOT_FOUND, "존재하지 않는 게시글 입니다");
 
     private String errorCode;
     private HttpStatus status;

--- a/src/main/java/com/car/sns/presentation/controller/ArticleController.java
+++ b/src/main/java/com/car/sns/presentation/controller/ArticleController.java
@@ -89,14 +89,11 @@ public class ArticleController {
     }
 
     @PutMapping("")
-    public ModelAndView modifyPostContent(@RequestBody ArticleModifyRequest articleModifyRequest,
-                                          @AuthenticationPrincipal CarAppPrincipal carAppPrincipal)
+    public ResponseEntity<Result> modifyPostContent(@RequestBody ArticleModifyRequest articleModifyRequest,
+                                                    @AuthenticationPrincipal CarAppPrincipal carAppPrincipal)
     {
         articleManagementUseCase.updateArticle(articleModifyRequest, carAppPrincipal.getUsername());
-
-        ModelAndView redirect = new ModelAndView("redirect:/articles/detail/");
-        redirect.addObject(articleModifyRequest.articleId());
-        return redirect;
+        return ResponseEntity.ok().body(Result.success(articleModifyRequest.articleId()));
     }
 
     /**

--- a/src/main/java/com/car/sns/presentation/model/request/ArticleModifyRequest.java
+++ b/src/main/java/com/car/sns/presentation/model/request/ArticleModifyRequest.java
@@ -2,14 +2,19 @@ package com.car.sns.presentation.model.request;
 
 import com.car.sns.domain.board.model.entity.Article;
 
+import java.util.Objects;
+
 /**
  * DTO for {@link Article}
  */
 public record ArticleModifyRequest(
         Long articleId,
         String title,
-        String content,
-        String createdBy) {
+        String content
+) {
+    public ArticleModifyRequest {
+        Objects.requireNonNull(articleId);
+    }
 
     public static ArticleModifyRequest of(Long articleId, String title, String content, String createdBy) {
         return ArticleModifyRequest.of(articleId, title, content, createdBy);

--- a/src/test/java/com/car/sns/domain/board/service/ArticleWriteServiceTest.java
+++ b/src/test/java/com/car/sns/domain/board/service/ArticleWriteServiceTest.java
@@ -1,0 +1,32 @@
+package com.car.sns.domain.board.service;
+
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@DisplayName("TODO")
+@ExtendWith(MockitoExtension.class)
+class ArticleWriteServiceTest {
+
+    @InjectMocks
+    private ArticleWriteService sut;
+
+    @Mock
+    private ArticleJpaRepository articleJpaRepository;
+
+    @DisplayName("given_when_then")
+    @WithMockUser
+    @Test
+    void given_when_then() {
+        //given
+
+        //when
+
+        //then
+    }
+}

--- a/src/test/java/com/car/sns/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/car/sns/repository/JpaRepositoryTest.java
@@ -3,7 +3,7 @@ package com.car.sns.repository;
 import com.car.sns.domain.board.model.entity.Article;
 import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
-import com.car.sns.domain.board.repository.ArticleRepository;
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +24,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("JPA 연결 테스트.")
 class JpaRepositoryTest {
 
-    private final ArticleRepository articleRepository;
+    private final ArticleJpaRepository articleRepository;
     private final ArticleCommentJpaRepository articleCommentRepository;
 
     public JpaRepositoryTest(
-            @Autowired  ArticleRepository articleRepository,
+            @Autowired ArticleJpaRepository articleRepository,
             @Autowired ArticleCommentJpaRepository articleCommentRepository)
     {
         this.articleRepository = articleRepository;

--- a/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
@@ -7,7 +7,7 @@ import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.domain.comment.service.read.ArticleCommentReadService;
 import com.car.sns.domain.user.model.UserAccountDto;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
-import com.car.sns.domain.board.repository.ArticleRepository;
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ class ArticleCommentServiceTest {
     @InjectMocks
     private ArticleCommentWriteService writeSut;
     @Mock
-    private ArticleRepository articleRepository;
+    private ArticleJpaRepository articleRepository;
     @Mock
     private ArticleCommentJpaRepository articleCommentRepository;
 

--- a/src/test/java/com/car/sns/service/ArticleServiceTest.java
+++ b/src/test/java/com/car/sns/service/ArticleServiceTest.java
@@ -7,7 +7,7 @@ import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.domain.board.model.type.SearchType;
 import com.car.sns.domain.board.model.ArticleDto;
 import com.car.sns.presentation.model.request.ArticleModifyRequest;
-import com.car.sns.domain.board.repository.ArticleRepository;
+import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -33,7 +33,7 @@ class ArticleServiceTest {
     @Mock
     private ArticleManagementUseCase articleManagementUseCase;
     @Mock
-    private ArticleRepository articleRepository;
+    private ArticleJpaRepository articleRepository;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
- 게시글 수정시 게시글 작성자와 수정요청자 일치여부 확인 후 일치하지 않는 경우 예외처리
- 게시글을 가져올 때 getReferenceById를 무조건 가져와서 데이터를 사용할 것 이기 때문에 findById로 메서드를 수정
- try~catch에서 람다식으로 변경

This closes #98