### PR TITLE
refact: 중복되는 DB IO 부분 개선

### DIFF
--- a/src/main/java/com/car/sns/application/usecase/alarm/AlarmDto.java
+++ b/src/main/java/com/car/sns/application/usecase/alarm/AlarmDto.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
  */
 public record AlarmDto(
         LocalDateTime createdAt,
-        String toUserId,
         AlarmType alarmType,
         AlarmArgs alarmArgs,
         String alarmText
@@ -19,7 +18,6 @@ public record AlarmDto(
     public static AlarmDto from(Alarm alarm) {
         return new AlarmDto(
                 alarm.getCreatedAt(),
-                alarm.getUserAccount().getUserId(),
                 alarm.getAlarmType(),
                 alarm.getAlarmArgs(),
                 alarm.getAlarmType().getAlarmText());

--- a/src/main/java/com/car/sns/application/usecase/like/LikeManagementUseCase.java
+++ b/src/main/java/com/car/sns/application/usecase/like/LikeManagementUseCase.java
@@ -1,5 +1,7 @@
 package com.car.sns.application.usecase.like;
 
+import com.car.sns.domain.user.model.UserAccountDto;
+
 public interface LikeManagementUseCase {
-    void saveLikeTarget(Long articleId, String userId);
+    void saveLikeTarget(Long articleId, UserAccountDto userAccountDto);
 }

--- a/src/main/java/com/car/sns/config/ClassUtils.java
+++ b/src/main/java/com/car/sns/config/ClassUtils.java
@@ -1,0 +1,10 @@
+package com.car.sns.config;
+
+import java.util.Optional;
+
+public class ClassUtils {
+    public static <T> Optional<T> getSafeCastInstance(Object o, Class<T> clazz) {
+        return clazz != null && clazz.isInstance(o) ? Optional.of(clazz.cast(o)) : Optional.empty();
+    }
+
+}

--- a/src/main/java/com/car/sns/domain/alarm/service/read/AlarmReadService.java
+++ b/src/main/java/com/car/sns/domain/alarm/service/read/AlarmReadService.java
@@ -2,10 +2,7 @@ package com.car.sns.domain.alarm.service.read;
 
 import com.car.sns.application.usecase.alarm.AlarmDto;
 import com.car.sns.application.usecase.alarm.AlarmReadUseCase;
-import com.car.sns.domain.user.model.entity.UserAccount;
-import com.car.sns.exception.CarHrSnsAppException;
 import com.car.sns.infrastructure.jpaRepository.AlarmJpaRepository;
-import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,15 +10,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.car.sns.exception.model.AppErrorCode.USER_NOTFOUND_ACCOUNT;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AlarmReadService implements AlarmReadUseCase {
 
-    private final UserAccountJpaRepository userAccountJpaRepository;
     private final AlarmJpaRepository alarmJpaRepository;
 
     /**
@@ -29,12 +23,6 @@ public class AlarmReadService implements AlarmReadUseCase {
      */
     @Override
     public Page<AlarmDto> alarmList(String userId, Pageable pageable) {
-        UserAccount toUserAccount = userAccountJpaRepository.findByUserId(userId).orElseThrow(() -> {
-            throw new CarHrSnsAppException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
-        });
-        Page<AlarmDto> alarmDtos = alarmJpaRepository.findByUserAccount(toUserAccount, pageable).map(AlarmDto::from);
-        log.info("alarmlist: {}", alarmDtos);
-
-        return alarmDtos;
+        return alarmJpaRepository.findByUserAccount(userId, pageable).map(AlarmDto::from);
     }
 }

--- a/src/main/java/com/car/sns/domain/board/service/ArticleWriteService.java
+++ b/src/main/java/com/car/sns/domain/board/service/ArticleWriteService.java
@@ -55,7 +55,6 @@ public class ArticleWriteService implements ArticleManagementUseCase {
 
     @Override
     public Result<ArticleDto> createArticle(CreateArticleInfoDto createArticleInfoDto) {
-        //article에 있는 해시태그 분리해서 저장
         UserAccount accessUser = userAccountJpaRepository.findByUserId(createArticleInfoDto.username())
                 .orElseThrow( () -> new EntityNotFoundException("잘못된 사용자 접속입니다."));
 

--- a/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
+++ b/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
@@ -7,7 +7,6 @@ import com.car.sns.domain.board.model.entity.Article;
 import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.domain.comment.model.entity.ArticleComment;
-import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
 import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,8 +28,7 @@ public class ArticleCommentWriteService implements ArticleCommentManagementUseCa
     @Override
     public void saveArticleComment(ArticleCommentDto articleCommentDto) {
         Article article = articleRepository.getReferenceById(articleCommentDto.articleId());
-        UserAccount userAccount = userAccountRepository.findByUserId(articleCommentDto.userAccountDto().userId()).orElseThrow();
-        ArticleComment articleComment = articleCommentDto.toEntity(article, userAccount);
+        ArticleComment articleComment = articleCommentDto.toEntity(article, articleCommentDto.userAccountDto().toEntity());
 
         if (articleCommentDto.hasParentComment()) {
             ArticleComment parentComment = articleCommentRepository.getReferenceById(articleCommentDto.parentCommentId());
@@ -40,8 +38,9 @@ public class ArticleCommentWriteService implements ArticleCommentManagementUseCa
 
             articleCommentRepository.save(articleComment).getId();
             alarmManagementUseCase.alarmOccurred(NEW_COMMENT_ON_ARTICLE,
-                    AlarmArgs.of(userAccount.getUserId(), article.getId()),
-                    article.getCreatedBy());
+                    AlarmArgs.of(articleComment.getUserAccount().getUserId(),
+                                article.getId()),
+                                article.getCreatedBy());
         }
     }
 

--- a/src/main/java/com/car/sns/domain/like/service/LikeWriteService.java
+++ b/src/main/java/com/car/sns/domain/like/service/LikeWriteService.java
@@ -6,10 +6,9 @@ import com.car.sns.domain.alarm.model.AlarmArgs;
 import com.car.sns.domain.board.model.entity.Article;
 import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import com.car.sns.domain.like.model.entity.Likes;
-import com.car.sns.domain.user.model.entity.UserAccount;
+import com.car.sns.domain.user.model.UserAccountDto;
 import com.car.sns.exception.CarHrSnsAppException;
 import com.car.sns.infrastructure.jpaRepository.LikeJpaRepository;
-import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static com.car.sns.domain.alarm.model.AlarmType.NEW_LIKE_ON_POST;
 import static com.car.sns.exception.model.AppErrorCode.ENTITY_NOT_FOUND;
-import static com.car.sns.exception.model.AppErrorCode.USER_NOTFOUND_ACCOUNT;
 
 @Slf4j
 @Service
@@ -26,27 +24,22 @@ import static com.car.sns.exception.model.AppErrorCode.USER_NOTFOUND_ACCOUNT;
 public class LikeWriteService implements LikeManagementUseCase {
 
     private final LikeJpaRepository likeJpaRepository;
-    private final UserAccountJpaRepository userAccountJpaRepository;
     private final ArticleJpaRepository articleJpaRepository;
     private final AlarmManagementUseCase alarmManagementUseCase;
 
     @Override
-    public void saveLikeTarget(Long articleId, String userId) {
-        //존재하는 사용자 인지 확인
-        UserAccount userAccount = userAccountJpaRepository.findByUserId(userId).orElseThrow(() -> {
-            throw new CarHrSnsAppException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
-        });
-
+    public void saveLikeTarget(Long articleId, UserAccountDto authorizedUser) {
         //존재하는 포스트인지 확인
         Article article = articleJpaRepository.findById(articleId).orElseThrow(() -> {
             throw new CarHrSnsAppException(ENTITY_NOT_FOUND, ENTITY_NOT_FOUND.getMessage());
         });
 
+        //TODO: 한 사람이 한번만 like를 할 수 있도록
         //좋아요 저장
-        likeJpaRepository.save(Likes.of(article, userAccount));
+        likeJpaRepository.save(Likes.of(article, authorizedUser.toEntity()));
         //알람 발생
         alarmManagementUseCase.alarmOccurred(NEW_LIKE_ON_POST,
-                AlarmArgs.of(userAccount.getUserId(), article.getId()),
+                AlarmArgs.of(authorizedUser.userId(), article.getId()),
                 article.getCreatedBy());
     }
 }

--- a/src/main/java/com/car/sns/exception/model/AppErrorCode.java
+++ b/src/main/java/com/car/sns/exception/model/AppErrorCode.java
@@ -23,7 +23,10 @@ public enum AppErrorCode {
     ENTITY_NOT_FOUND                ("SV1001", HttpStatus.NOT_FOUND, "존재하지 않는 게시글 입니다"),
 
     //DB
-    DATABASE_INSERT_FAIL            ("DB0001", HttpStatus.EXPECTATION_FAILED, "데이터베이스 등록 실패");
+    DATABASE_INSERT_FAIL            ("DB0001", HttpStatus.EXPECTATION_FAILED, "데이터베이스 등록 실패"),
+
+    //서버
+    INTERNAL_SERVER_ERROR           ("SER001", HttpStatus.INTERNAL_SERVER_ERROR, "internal server error");
 
     private String errorCode;
     private HttpStatus status;

--- a/src/main/java/com/car/sns/infrastructure/jpaRepository/AlarmJpaRepository.java
+++ b/src/main/java/com/car/sns/infrastructure/jpaRepository/AlarmJpaRepository.java
@@ -1,11 +1,13 @@
 package com.car.sns.infrastructure.jpaRepository;
 
 import com.car.sns.domain.alarm.model.entity.Alarm;
-import com.car.sns.domain.user.model.entity.UserAccount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AlarmJpaRepository extends JpaRepository<Alarm, Long> {
-    Page<Alarm> findByUserAccount(UserAccount userAccount, Pageable pageable);
+    @Query("select a from Alarm a where a.userAccount.userId = :userId")
+    Page<Alarm> findByUserAccount(@Param("userId") String userId, Pageable pageable);
 }

--- a/src/main/java/com/car/sns/presentation/controller/LikeController.java
+++ b/src/main/java/com/car/sns/presentation/controller/LikeController.java
@@ -26,7 +26,7 @@ public class LikeController {
     @GetMapping("/{articleId}")
     public ResponseEntity<Result> saveLikeToArticle(@PathVariable("articleId") Long articleId,
                                                     @AuthenticationPrincipal CarAppPrincipal carAppPrincipal) {
-        likeManagementUseCase.saveLikeTarget(articleId, carAppPrincipal.getName());
+        likeManagementUseCase.saveLikeTarget(articleId, carAppPrincipal.userAccountDto());
         return ResponseEntity.ok().body(Result.success(null));
     }
 

--- a/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
+++ b/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
@@ -31,13 +31,7 @@ public record ArticleCommentRequest(
         return ArticleCommentDto.of(
                 articleId,
                 parentCommentId,
-                UserAccountDto.of(
-                    carAppPrincipal.getUsername(),
-                    carAppPrincipal.getPassword(),
-                    carAppPrincipal.email(),
-                    carAppPrincipal.nickname(),
-                    carAppPrincipal.memo()
-                ),
+                carAppPrincipal.userAccountDto(),
                 content);
     }
 }

--- a/src/main/java/com/car/sns/security/CarAppPrincipal.java
+++ b/src/main/java/com/car/sns/security/CarAppPrincipal.java
@@ -22,11 +22,18 @@ public record CarAppPrincipal(
         String email,
         String nickname,
         String memo,
+        UserAccountDto userAccountDto,
         Map<String, Object> oAuth2Attribute
 
 ) implements UserDetails, OAuth2User {
 
-    public static CarAppPrincipal of(String username, String password, String email, String nickname, String memo, Map<String, Object> oAuth2Attribute) {
+    public static CarAppPrincipal of(String username,
+                                     String password,
+                                     String email,
+                                     String nickname,
+                                     String memo,
+                                     UserAccountDto userAccountDto,
+                                     Map<String, Object> oAuth2Attribute) {
         Set<RoleType> roleTypes = Set.of(RoleType.USER);
 
         return new CarAppPrincipal(
@@ -39,11 +46,17 @@ public record CarAppPrincipal(
                 email,
                 nickname,
                 memo,
+                userAccountDto,
                 oAuth2Attribute);
     }
 
-    public static CarAppPrincipal of(String username, String password, String email, String nickname, String memo) {
-        return CarAppPrincipal.of(username, password, email, nickname, memo, Map.of());
+    public static CarAppPrincipal of(String username,
+                                     String password,
+                                     String email,
+                                     String nickname,
+                                     String memo,
+                                     UserAccountDto userAccountDto) {
+        return CarAppPrincipal.of(username, password, email, nickname, memo, userAccountDto, Map.of());
     }
 
     public static CarAppPrincipal from(UserAccountDto userAccountDto) {
@@ -52,7 +65,8 @@ public record CarAppPrincipal(
                 userAccountDto.userPassword(),
                 userAccountDto.email(),
                 userAccountDto.nickname(),
-                userAccountDto.memo());
+                userAccountDto.memo(),
+                userAccountDto);
     }
 
     public UserAccountDto toDto() {

--- a/src/main/java/com/car/sns/security/JwtTokenFilter.java
+++ b/src/main/java/com/car/sns/security/JwtTokenFilter.java
@@ -58,7 +58,6 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                     CarAppPrincipal.from(userAccountDto), null, null
             );
-
             authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 

--- a/src/test/java/com/car/sns/presentation/controller/LikeControllerTest.java
+++ b/src/test/java/com/car/sns/presentation/controller/LikeControllerTest.java
@@ -1,6 +1,7 @@
 package com.car.sns.presentation.controller;
 
 import com.car.sns.application.usecase.like.LikeManagementUseCase;
+import com.car.sns.domain.user.model.UserAccountDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -52,7 +54,7 @@ class LikeControllerTest {
         //given
         Long articleId = 1L;
         String userId = "seoyun33";
-        willDoNothing().given(likeManagementUseCase).saveLikeTarget(eq(articleId), eq(userId));
+        willDoNothing().given(likeManagementUseCase).saveLikeTarget(eq(articleId), any(UserAccountDto.class));
 
         //when
         mockMvc.perform(get("/like/" + articleId)
@@ -60,6 +62,6 @@ class LikeControllerTest {
                 .andExpect(status().isOk());
 
         //then
-        then(likeManagementUseCase).should().saveLikeTarget(eq(articleId), eq(userId));
+        then(likeManagementUseCase).should().saveLikeTarget(eq(articleId), any(UserAccountDto.class));
     }
 }


### PR DESCRIPTION
- spring security를 통해 필터단에서 사용자를 조회하고 권한을 부여하는 부분을 거친 뒤 API 요청을 받게 되는데 이후 서비스 로직에서 다시 한번 사용자를 조회하여 DB에서 가져오는 로직이 존재한다 따라서 쿼리가 API 요청시 무조건 사용자 조회 쿼리가 두번 나간다
-  이를 개선하기 위해서 @AuthenticationPrincipal를 통해서 Authentication에서 추출하여 사용자 데이터를 저장할 수 있도록 만들어 줬다

This closes #104