### PR TITLE
Feature/#106 redis caching

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.3.1'
     implementation 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/car/sns/application/usecase/user/UserReadUseCase.java
+++ b/src/main/java/com/car/sns/application/usecase/user/UserReadUseCase.java
@@ -1,12 +1,12 @@
 package com.car.sns.application.usecase.user;
 
 import com.car.sns.domain.user.model.LoginDto;
-import com.car.sns.domain.user.model.UserAccountDto;
 import com.car.sns.presentation.model.response.UserLoginResponse;
+import com.car.sns.security.CarAppPrincipal;
 
 import java.util.Optional;
 
 public interface UserReadUseCase {
-    Optional<UserAccountDto> searchUser(String username);
+    Optional<CarAppPrincipal> searchUser(String username);
     UserLoginResponse login(LoginDto loginDto);
 }

--- a/src/main/java/com/car/sns/config/RedisConfig.java
+++ b/src/main/java/com/car/sns/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.car.sns.config;
+
+import com.car.sns.security.CarAppPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Slf4j
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    // jackson LocalDateTime mapper
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+        return mapper;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        //RedisURI redisURI = RedisURI.create(redisProperties.getUrl());
+        //RedisConfiguration configuration = LettuceConnectionFactory.createRedisConfiguration(redisURI);
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        //factory.afterPropertiesSet();//이니셜라이징
+        return factory;
+    }
+
+    @Bean
+    public RedisTemplate<String, CarAppPrincipal> userRedisTemplate(RedisConnectionFactory redisConnectionFactory) {//redis에서 사용하는 command를 사용할 수 있다.
+        RedisTemplate<String, CarAppPrincipal> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory); //redis 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(objectMapper(), CarAppPrincipal.class));
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/car/sns/domain/comment/model/ArticleCommentDto.java
+++ b/src/main/java/com/car/sns/domain/comment/model/ArticleCommentDto.java
@@ -2,8 +2,8 @@ package com.car.sns.domain.comment.model;
 
 import com.car.sns.domain.board.model.entity.Article;
 import com.car.sns.domain.comment.model.entity.ArticleComment;
-import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.domain.user.model.entity.UserAccount;
 
 import java.time.LocalDateTime;
 import java.util.Comparator;

--- a/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
+++ b/src/main/java/com/car/sns/domain/comment/service/ArticleCommentWriteService.java
@@ -8,7 +8,6 @@ import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.domain.comment.model.entity.ArticleComment;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
-import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +21,6 @@ public class ArticleCommentWriteService implements ArticleCommentManagementUseCa
 
     private final ArticleJpaRepository articleRepository;
     private final ArticleCommentJpaRepository articleCommentRepository;
-    private final UserAccountJpaRepository userAccountRepository;
     private final AlarmManagementUseCase alarmManagementUseCase;
 
     @Override

--- a/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
+++ b/src/main/java/com/car/sns/domain/user/service/UserAccountReadService.java
@@ -3,10 +3,11 @@ package com.car.sns.domain.user.service;
 import com.car.sns.application.usecase.user.UserReadUseCase;
 import com.car.sns.domain.user.model.LoginDto;
 import com.car.sns.domain.user.model.UserAccountDto;
-import com.car.sns.domain.user.model.entity.UserAccount;
 import com.car.sns.exception.CarHrSnsAppException;
+import com.car.sns.infrastructure.UserCacheRepository;
 import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
 import com.car.sns.presentation.model.response.UserLoginResponse;
+import com.car.sns.security.CarAppPrincipal;
 import com.car.sns.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,33 +32,37 @@ public class UserAccountReadService implements UserReadUseCase {
     private long expireTimeMs = 1000 * 60 * 60; //TODO:test를 위한것으로 Redis implement
     private final PasswordEncoder passwordEncoder;
     private final UserAccountJpaRepository userAccountJpaRepository;
+    private final UserCacheRepository userCacheRepository;
 
     /**
      *  Optional로 반환하는 이유는 해당 service에서 결정하는 것이 아니라
      *  user만 찾고 이후 단계는 앞단에서 맞는 exception으로 맞춰줄 것
+     *  캐시에 올라간 상태인지 확인 후 DB 요청
      */
-    public Optional<UserAccountDto> searchUser(String username) {
-        return userAccountJpaRepository.findByUserId(username)
-                .map(UserAccountDto::from);
+    public Optional<CarAppPrincipal> searchUser(String username) {
+        CarAppPrincipal carAppPrincipal = userCacheRepository.getUser(username).orElseGet(() ->
+                userAccountJpaRepository.findByUserId(username)
+                        .map(UserAccountDto::from)
+                        .map(CarAppPrincipal::from)
+                        .orElseThrow(() -> {
+                            throw new CarHrSnsAppException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
+                        })
+        );
+        return Optional.of(carAppPrincipal);
     }
 
     @Override
     public UserLoginResponse login(LoginDto loginDto) {
-        UserAccountDto userAccountDto = userAccountJpaRepository.findByUserId(loginDto.userId())
+        userAccountJpaRepository.findByUserId(loginDto.userId())
                 .filter(user -> passwordEncoder.matches(loginDto.password(), user.getUserPassword()))
                 .map(UserAccountDto::from)
-                .orElseThrow(() -> {
+                .ifPresentOrElse(
+                        userAccountDto -> userCacheRepository.setUser(CarAppPrincipal.from(userAccountDto)),
+                        () -> {
                     throw new CarHrSnsAppException(INVALID_USER_ID_PASSWORD, INVALID_USER_ID_PASSWORD.getMessage());
                 });
 
-        log.info("login userAccountDto: {}", userAccountDto);
-        return  UserLoginResponse.of(JwtUtil.createToken(userAccountDto.userId(), secretKey, expireTimeMs));
-    }
-
-    public UserAccount loadUserByUserName(String userId) {
-        return userAccountJpaRepository.findByUserId(userId)
-                .orElseThrow(
-                        () -> new CarHrSnsAppException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage() + ":" + userId)
-                );
+        log.info("login userAccountDto: {}", loginDto);
+        return  UserLoginResponse.of(JwtUtil.createToken(loginDto.userId(), secretKey, expireTimeMs));
     }
 }

--- a/src/main/java/com/car/sns/infrastructure/UserCacheRepository.java
+++ b/src/main/java/com/car/sns/infrastructure/UserCacheRepository.java
@@ -1,0 +1,39 @@
+package com.car.sns.infrastructure;
+
+import com.car.sns.security.CarAppPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class UserCacheRepository {
+    private final RedisTemplate<String, CarAppPrincipal> userRedisTemplate;
+    private final static Duration USER_CACHE_TTL = Duration.ofDays(3);
+    private final ObjectMapper objectMapper;
+
+    public void setUser(CarAppPrincipal carAppPrincipal) {
+        String key = getKey(carAppPrincipal.getUsername());
+        log.info("set user to redis {} : {}", key, carAppPrincipal);
+        userRedisTemplate.opsForValue().set(key, carAppPrincipal, USER_CACHE_TTL);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<CarAppPrincipal> getUser(String userId) {
+        String key = getKey(userId);
+        CarAppPrincipal carAppPrincipal = userRedisTemplate.opsForValue().get(key);
+        log.info("get user from redis {} : {}", key, carAppPrincipal);
+        return Optional.of(carAppPrincipal);
+    }
+
+    public String getKey(String userId) {//필터단에서 userId를 사용하기 때문에 userId로 설정
+        return "USER:" + userId;
+    }
+}

--- a/src/main/java/com/car/sns/presentation/controller/UserController.java
+++ b/src/main/java/com/car/sns/presentation/controller/UserController.java
@@ -10,7 +10,10 @@ import com.car.sns.presentation.model.response.Result;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
+++ b/src/main/java/com/car/sns/presentation/model/request/ArticleCommentRequest.java
@@ -1,9 +1,8 @@
 package com.car.sns.presentation.model.request;
 
-import com.car.sns.domain.comment.model.entity.ArticleComment;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
+import com.car.sns.domain.comment.model.entity.ArticleComment;
 import com.car.sns.domain.user.model.UserAccountDto;
-import com.car.sns.security.CarAppPrincipal;
 
 /**
  * DTO for {@link ArticleComment}
@@ -27,7 +26,7 @@ public record ArticleCommentRequest(
         return ArticleCommentDto.of(articleId, parentCommentId, userAccountDto, content);
     }
 
-    public ArticleCommentDto toDto(CarAppPrincipal carAppPrincipal) {
+    public ArticleCommentDto toDto(com.car.sns.security.CarAppPrincipal carAppPrincipal) {
         return ArticleCommentDto.of(
                 articleId,
                 parentCommentId,

--- a/src/main/java/com/car/sns/security/CarAppPrincipal.java
+++ b/src/main/java/com/car/sns/security/CarAppPrincipal.java
@@ -2,6 +2,8 @@ package com.car.sns.security;
 
 import com.car.sns.domain.user.model.UserAccountDto;
 import com.car.sns.exception.CarHrSnsAppException;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,6 +16,7 @@ import java.util.stream.Collectors;
 
 import static com.car.sns.exception.model.AppErrorCode.AUTHENTICATION_TOKEN_EXIST;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record CarAppPrincipal(
         //entity에서 사용하는 이름이 아닌 principal에서 사용하는 이름을 따라감
         Collection<? extends GrantedAuthority> authorities,
@@ -23,9 +26,7 @@ public record CarAppPrincipal(
         String nickname,
         String memo,
         UserAccountDto userAccountDto,
-        Map<String, Object> oAuth2Attribute
-
-) implements UserDetails, OAuth2User {
+        Map<String, Object> oAuth2Attribute) implements UserDetails, OAuth2User {
 
     public static CarAppPrincipal of(String username,
                                      String password,
@@ -82,6 +83,7 @@ public record CarAppPrincipal(
         return oAuth2Attribute;
     }
 
+    @JsonIgnore
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;
@@ -103,21 +105,25 @@ public record CarAppPrincipal(
         return username;
     }
 
+    @JsonIgnore
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
 
+    @JsonIgnore
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
 
+    @JsonIgnore
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
 
+    @JsonIgnore
     @Override
     public boolean isEnabled() {
         return true;

--- a/src/main/java/com/car/sns/security/JwtTokenFilter.java
+++ b/src/main/java/com/car/sns/security/JwtTokenFilter.java
@@ -1,7 +1,7 @@
 package com.car.sns.security;
 
 import com.car.sns.application.usecase.user.UserReadUseCase;
-import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.exception.CarHrSnsAppException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,6 +17,8 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.car.sns.exception.model.AppErrorCode.USER_NOTFOUND_ACCOUNT;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -53,10 +55,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             }
 
             String userId = JwtUtil.getUserName(token, secretKey);
-            UserAccountDto userAccountDto = userReadUseCase.searchUser(userId).orElseThrow();
+            CarAppPrincipal carAppPrincipal = userReadUseCase.searchUser(userId).orElseThrow(() -> {
+                throw new CarHrSnsAppException(USER_NOTFOUND_ACCOUNT, USER_NOTFOUND_ACCOUNT.getMessage());
+            });
 
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                    CarAppPrincipal.from(userAccountDto), null, null
+                    carAppPrincipal, null, null
             );
             authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);

--- a/src/test/java/com/car/sns/domain/user/service/UserAccountReadServiceTest.java
+++ b/src/test/java/com/car/sns/domain/user/service/UserAccountReadServiceTest.java
@@ -1,8 +1,8 @@
 package com.car.sns.domain.user.service;
 
 import com.car.sns.domain.user.model.entity.UserAccount;
-import com.car.sns.domain.user.model.UserAccountDto;
 import com.car.sns.infrastructure.jpaRepository.UserAccountJpaRepository;
+import com.car.sns.security.CarAppPrincipal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +35,7 @@ class UserAccountReadServiceTest {
                 .willReturn(Optional.of(createUserAccount(username)));
 
         //when
-        Optional<UserAccountDto> result = sut.searchUser(username);
+        Optional<CarAppPrincipal> result = sut.searchUser(username);
 
         //then
         assertThat(result).isPresent();

--- a/src/test/java/com/car/sns/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/car/sns/presentation/controller/UserControllerTest.java
@@ -2,7 +2,7 @@ package com.car.sns.presentation.controller;
 
 import com.car.sns.application.usecase.user.UserManagementUseCase;
 import com.car.sns.application.usecase.user.UserReadUseCase;
-import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.domain.user.model.CarAppPrincipal;
 import com.car.sns.presentation.model.request.RegisterAccountRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,8 +71,8 @@ class UserControllerTest {
                 "memo");
     }
 
-    private UserAccountDto createUserAccountDto() {
-        return UserAccountDto.of(
+    private CarAppPrincipal createUserAccountDto() {
+        return CarAppPrincipal.of(
                 "userId",
                 "password1234",
                 "email@email.com",

--- a/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/car/sns/service/ArticleCommentServiceTest.java
@@ -5,7 +5,7 @@ import com.car.sns.domain.board.model.entity.Article;
 import com.car.sns.domain.comment.model.entity.ArticleComment;
 import com.car.sns.domain.comment.model.ArticleCommentDto;
 import com.car.sns.domain.comment.service.read.ArticleCommentReadService;
-import com.car.sns.domain.user.model.UserAccountDto;
+import com.car.sns.domain.user.model.CarAppPrincipal;
 import com.car.sns.infrastructure.jpaRepository.ArticleCommentJpaRepository;
 import com.car.sns.domain.board.repository.ArticleJpaRepository;
 import org.junit.jupiter.api.Disabled;
@@ -70,12 +70,12 @@ class ArticleCommentServiceTest {
     }
 
     private ArticleCommentDto createdArticleCommentDto(String content) {
-        UserAccountDto userAccountDto = UserAccountDto.of(null, "uno", "uno", "pw", "email@email.com", "nickname", null);
+        CarAppPrincipal userAccountDto = CarAppPrincipal.of(null, "uno", "uno", "pw", "email@email.com", "nickname", null);
         return ArticleCommentDto.of(1L, userAccountDto, content);
     }
 
     private Article createArticle() {
-        UserAccountDto userAccountDto = UserAccountDto.of(null, null, "uno", "pw", "email@email.com", "nickname", null);
+        CarAppPrincipal userAccountDto = CarAppPrincipal.of(null, null, "uno", "pw", "email@email.com", "nickname", null);
         return Article.of(userAccountDto.toEntity(), "title", "content");
     }
 }


### PR DESCRIPTION
redis 설정
- DB IO 부하를 줄이기 위해서 redis를 통해 빈번하게 발생하나 데이터의 업데이트가 거의 없는 사용자 정보를 caching 하기로 결정 (현재 회원수정 기능 구현은 되어있지 않다)
- redisTemplate 설정
- redis configuration 설정
- redis에 set, get을 할 수 있도록 기능 구현
- 인증된 사용자를 나타내는  model 객체 리팩토링

불필요한 코드 및 import 정리
- UserAccountDto 클래스가 다른 클래스로 변경되면서 모든 클래스에 반영되었다 코드 수정을 반영
- 불필요한 메서드 제거

캐시 로직 구성
- 기존 DB에서 데이터를 조회하던 searchUser 메서드에서 1차적으로 cache에서 해당 사용자의 정보를 조회한 뒤 존재하지 않으면 DB에 가져와서 캐시에 저장하도록 구현

---

redis 적용 후 테스트 중 데이터를 조회할 때 parsing이 제대로 되지 않는 현상 발생
도중에 발생한 에러를 정리한 링크 첨부
//TODO
